### PR TITLE
Extended data and kernel base classes to have ephemeral property fields

### DIFF
--- a/src/reactions_lib/reaction_data.hpp
+++ b/src/reactions_lib/reaction_data.hpp
@@ -72,8 +72,14 @@ struct AbstractCrossSection {
  * regarding the required INT-based properties for the reaction data.
  * @param required_real_props Properties<REAL> object containing information
  * regarding the required REAL-based properties for the reaction data.
- * @param properties_map_ A std::map<int, std::string> object to be used when
- * retrieving property names (in get_required_real_props(...) and
+ * @param required_int_props_ephemeral Properties<INT> object containing
+ * information regarding the required INT-based ephemeral properties for the
+ * reaction data.
+ * @param required_real_props_ephemeral Properties<REAL> object containing
+ * information regarding the required REAL-based ephemeral properties for the
+ * reaction data.
+ * @param properties_map A std::map<int, std::string> object to be used when
+ * retrieven property names, i.e. remapping default property names
  * get_required_int_props(...)).
  */
 template <size_t dim = 1, typename RNG_TYPE = HostPerParticleBlockRNG<REAL>>
@@ -82,38 +88,82 @@ struct ReactionDataBase {
   using RNG_KERNEL_TYPE = RNG_TYPE;
   ReactionDataBase(Properties<INT> required_int_props,
                    Properties<REAL> required_real_props,
-                   std::map<int, std::string> properties_map_ = default_map)
+                   Properties<INT> required_int_props_ephemeral,
+                   Properties<REAL> required_real_props_ephemeral,
+                   std::map<int, std::string> properties_map = default_map)
       : required_int_props(required_int_props),
         required_real_props(required_real_props),
-        properties_map(properties_map_) {
+        required_int_props_ephemeral(required_int_props_ephemeral),
+        required_real_props_ephemeral(required_real_props_ephemeral),
+        properties_map(properties_map) {
     auto rng_lambda = [&]() -> REAL { return 0; };
     this->rng_kernel = std::make_shared<RNG_TYPE>(rng_lambda, 0);
   }
 
-  ReactionDataBase(std::map<int, std::string> properties_map_ = default_map)
+  ReactionDataBase(std::map<int, std::string> properties_map = default_map)
       : ReactionDataBase(Properties<INT>(), Properties<REAL>(),
-                         properties_map_) {}
+                         Properties<INT>(), Properties<REAL>(),
+                         properties_map) {}
 
   ReactionDataBase(Properties<INT> required_int_props,
-                   std::map<int, std::string> properties_map_ = default_map)
+                   std::map<int, std::string> properties_map = default_map)
       : ReactionDataBase(required_int_props, Properties<REAL>(),
-                         properties_map_) {}
+                         Properties<INT>(), Properties<REAL>(),
+                         properties_map) {}
 
   ReactionDataBase(Properties<REAL> required_real_props,
-                   std::map<int, std::string> properties_map_ = default_map)
+                   std::map<int, std::string> properties_map = default_map)
       : ReactionDataBase(Properties<INT>(), required_real_props,
-                         properties_map_) {}
+                         Properties<INT>(), Properties<REAL>(),
+                         properties_map) {}
 
+  ReactionDataBase(Properties<INT> required_int_props,
+                   Properties<REAL> required_real_props,
+                   std::map<int, std::string> properties_map = default_map)
+      : ReactionDataBase(required_int_props, required_real_props,
+                         Properties<INT>(), Properties<REAL>(),
+                         properties_map) {}
   /**
-   * Getters for the vector of std::string objects that represent the names of
-   * either INT or REAL-based properties.
+   * @brief Return all required integer property names, including ephemeral
+   * properties
+   *
    */
   std::vector<std::string> get_required_int_props() {
-    return this->required_int_props.get_prop_names(this->properties_map);
+    auto names = this->required_int_props.get_prop_names(this->properties_map);
+    auto ephemeral_names =
+        this->required_int_props_ephemeral.get_prop_names(this->properties_map);
+    names.insert(names.end(), ephemeral_names.begin(), ephemeral_names.end());
+    return names;
   }
 
+  /**
+   * @brief Return all required real property names, including ephemeral
+   * properties
+   *
+   */
   std::vector<std::string> get_required_real_props() {
-    return this->required_real_props.get_prop_names(this->properties_map);
+    auto names = this->required_real_props.get_prop_names(this->properties_map);
+    auto ephemeral_names = this->required_real_props_ephemeral.get_prop_names(
+        this->properties_map);
+    names.insert(names.end(), ephemeral_names.begin(), ephemeral_names.end());
+    return names;
+  }
+
+  /**
+   * @brief Return names of required ephemeral integer properties
+   *
+   */
+  std::vector<std::string> get_required_int_props_ephemeral() {
+    return this->required_int_props_ephemeral.get_prop_names(
+        this->properties_map);
+  }
+  /**
+   * @brief Return names of required ephemeral real properties
+   *
+   */
+  std::vector<std::string> get_required_real_props_ephemeral() {
+    return this->required_real_props_ephemeral.get_prop_names(
+        this->properties_map);
   }
 
   void set_rng_kernel(std::shared_ptr<RNG_TYPE> rng_kernel) {
@@ -127,6 +177,8 @@ struct ReactionDataBase {
 protected:
   Properties<INT> required_int_props;
   Properties<REAL> required_real_props;
+  Properties<INT> required_int_props_ephemeral;
+  Properties<REAL> required_real_props_ephemeral;
   std::shared_ptr<RNG_TYPE> rng_kernel;
   std::map<int, std::string> properties_map;
 };

--- a/src/reactions_lib/reaction_kernels.hpp
+++ b/src/reactions_lib/reaction_kernels.hpp
@@ -13,44 +13,102 @@ namespace Reactions {
  * regarding the required INT-based properties for the reaction kernel.
  * @param required_real_props Properties<REAL> object containing information
  * regarding the required REAL-based properties for the reaction kernel.
+ * @param required_int_props_ephemeral Properties<INT> object containing
+ * information regarding the required INT-based ephemeral properties for the
+ * reaction kernel.
+ * @param required_real_props_ephemeral Properties<REAL> object containing
+ * information regarding the required REAL-based properties for the reaction
+ * kernel.
  * @param pre_req_ndims Integer defining the number of dimensions required by a
  * reaction kernel (this in turn matches the number of ReactionData-derived
  * objects that must be passed to the constructor of a DataCalculator object
  * when this kernel and the DataCalculator object are passed to a
  * LinearReactionBase-derived object constructor).
- * @param properties_map_ A std::map<int, std::string> object to be used when
+ * @param properties_map A std::map<int, std::string> object to be used when
  * retrieving property names (in get_required_real_props(...) and
  * get_required_int_props(...)).
  */
 struct ReactionKernelsBase {
-  ReactionKernelsBase(std::map<int, std::string> properties_map_ = default_map)
-      : properties_map(properties_map_) {}
+
+  ReactionKernelsBase(Properties<INT> required_int_props,
+                      Properties<REAL> required_real_props,
+                      Properties<INT> required_int_props_ephemeral,
+                      Properties<REAL> required_real_props_ephemeral,
+                      INT pre_req_ndims = 0,
+                      std::map<int, std::string> properties_map = default_map)
+      : required_int_props(required_int_props),
+        required_real_props(required_real_props),
+        required_int_props_ephemeral(required_int_props_ephemeral),
+        required_real_props_ephemeral(required_real_props_ephemeral),
+        pre_req_ndims(pre_req_ndims), properties_map(properties_map) {}
+
+  ReactionKernelsBase(std::map<int, std::string> properties_map = default_map)
+      : ReactionKernelsBase(Properties<INT>(), Properties<REAL>(),
+                            Properties<INT>(), Properties<REAL>(), 0,
+                            properties_map) {}
 
   ReactionKernelsBase(Properties<INT> required_int_props, INT pre_req_ndims = 0,
-                      std::map<int, std::string> properties_map_ = default_map)
-      : required_int_props(required_int_props), pre_req_ndims(pre_req_ndims),
-        properties_map(properties_map_) {}
+                      std::map<int, std::string> properties_map = default_map)
+      : ReactionKernelsBase(required_int_props, Properties<REAL>(),
+                            Properties<INT>(), Properties<REAL>(),
+                            pre_req_ndims, properties_map) {}
 
   ReactionKernelsBase(Properties<REAL> required_real_props,
                       INT pre_req_ndims = 0,
-                      std::map<int, std::string> properties_map_ = default_map)
-      : required_real_props(required_real_props), pre_req_ndims(pre_req_ndims),
-        properties_map(properties_map_) {}
+                      std::map<int, std::string> properties_map = default_map)
+      : ReactionKernelsBase(Properties<INT>(), required_real_props,
+                            Properties<INT>(), Properties<REAL>(),
+                            pre_req_ndims, properties_map) {}
 
   ReactionKernelsBase(Properties<INT> required_int_props,
                       Properties<REAL> required_real_props,
                       INT pre_req_ndims = 0,
-                      std::map<int, std::string> properties_map_ = default_map)
-      : required_int_props(required_int_props),
-        required_real_props(required_real_props), pre_req_ndims(pre_req_ndims),
-        properties_map(properties_map_) {}
+                      std::map<int, std::string> properties_map = default_map)
+      : ReactionKernelsBase(required_int_props, required_real_props,
+                            Properties<INT>(), Properties<REAL>(),
+                            pre_req_ndims, properties_map) {}
 
+  /**
+   * @brief Return all required integer property names, including ephemeral
+   * properties
+   *
+   */
   std::vector<std::string> get_required_int_props() {
-    return this->required_int_props.get_prop_names(this->properties_map);
+    auto names = this->required_int_props.get_prop_names(this->properties_map);
+    auto ephemeral_names =
+        this->required_int_props_ephemeral.get_prop_names(this->properties_map);
+    names.insert(names.end(), ephemeral_names.begin(), ephemeral_names.end());
+    return names;
   }
 
+  /**
+   * @brief Return all required real property names, including ephemeral
+   * properties
+   *
+   */
   std::vector<std::string> get_required_real_props() {
-    return this->required_real_props.get_prop_names(this->properties_map);
+    auto names = this->required_real_props.get_prop_names(this->properties_map);
+    auto ephemeral_names = this->required_real_props_ephemeral.get_prop_names(
+        this->properties_map);
+    names.insert(names.end(), ephemeral_names.begin(), ephemeral_names.end());
+    return names;
+  }
+
+  /**
+   * @brief Return names of required ephemeral integer properties
+   *
+   */
+  std::vector<std::string> get_required_int_props_ephemeral() {
+    return this->required_int_props_ephemeral.get_prop_names(
+        this->properties_map);
+  }
+  /**
+   * @brief Return names of required ephemeral real properties
+   *
+   */
+  std::vector<std::string> get_required_real_props_ephemeral() {
+    return this->required_real_props_ephemeral.get_prop_names(
+        this->properties_map);
   }
 
   const Properties<INT> &get_required_descendant_int_props() {
@@ -116,6 +174,9 @@ protected:
 
   Properties<INT> required_int_props;
   Properties<REAL> required_real_props;
+
+  Properties<INT> required_int_props_ephemeral;
+  Properties<REAL> required_real_props_ephemeral;
 
   Properties<INT> required_descendant_int_props;
   Properties<REAL> required_descendant_real_props;

--- a/test/unit/include/mock_reactions.hpp
+++ b/test/unit/include/mock_reactions.hpp
@@ -382,3 +382,24 @@ struct TestReactionVarRate : public LinearReactionBase<0, TestReactionVarData,
             sycl_target_, in_states_, std::array<int, 0>{},
             TestReactionVarData(), TestReactionVarKernels(), particle_spec) {}
 };
+
+// TODO: Add corresponding kernel for ephemeral dat test
+struct TestEphemeralVarData : public ReactionDataBase<> {
+
+  constexpr static auto props = default_properties;
+
+  constexpr static std::array<int, 1> required_simple_real_props = {
+      props.weight};
+
+  constexpr static std::array<int, 1> required_simple_real_props_ephemeral = {
+      props.velocity};
+
+  TestEphemeralVarData(std::map<int, std::string> properties_map = default_map)
+      : ReactionDataBase(Properties<INT>(),
+                         Properties<REAL>(required_simple_real_props),
+                         Properties<INT>(),
+                         Properties<REAL>(required_simple_real_props_ephemeral),
+                         properties_map) {}
+
+  // TODO: Add device type for later tests
+};

--- a/test/unit/test_reaction_data.cpp
+++ b/test/unit/test_reaction_data.cpp
@@ -1,5 +1,6 @@
 #include "include/mock_particle_group.hpp"
 #include "include/mock_reactions.hpp"
+#include <cmath>
 #include <gtest/gtest.h>
 
 using namespace NESO::Particles;
@@ -174,4 +175,32 @@ TEST(ReactionData, AMJUEL2DData_coronal) {
   }
 
   particle_group->domain->mesh->free();
+}
+
+TEST(ReactionData, EphemeralPropertiesReactionData) {
+
+  auto test_data = TestEphemeralVarData();
+
+  auto expected_prop_names =
+      std::vector<std::string>{default_map.at(default_properties.weight),
+                               default_map.at(default_properties.velocity)};
+
+  auto test_prop_names = test_data.get_required_real_props();
+
+  ASSERT_EQ(expected_prop_names.size(), test_prop_names.size());
+  for (int i = 0; i < test_prop_names.size(); i++) {
+    EXPECT_EQ(expected_prop_names[i], test_prop_names[i]);
+  }
+
+  auto expected_prop_names_ephemeral = 
+      std::vector<std::string>{default_map.at(default_properties.velocity)};
+
+  auto test_prop_names_ephemeral =
+      test_data.get_required_real_props_ephemeral();
+
+  ASSERT_EQ(expected_prop_names_ephemeral.size(),
+            test_prop_names_ephemeral.size());
+  for (int i = 0; i < test_prop_names_ephemeral.size(); i++) {
+    EXPECT_EQ(expected_prop_names_ephemeral[i], test_prop_names_ephemeral[i]);
+  }
 }


### PR DESCRIPTION
ReactionDataBase and ReactionKernelBase now have the option of two more arguments for ephemeral dats, and differentiated getters. 

Basic test added, but will be extended when I add an ephemeral dat mock kernel in a separate PR next week. 

Also changed some constructors and naming according to #47 and #86, but these are far from being closed.