### PR TITLE
ReactionController refactor to use enum for modes

### DIFF
--- a/src/reactions_lib/reaction_controller.hpp
+++ b/src/reactions_lib/reaction_controller.hpp
@@ -180,8 +180,9 @@ public:
    * @param particle_group The ParticleGroup to apply the reactions to.
    * @param dt The current time step size.
    */
-  void apply_reactions(ParticleGroupSharedPtr particle_group, double dt,
-                       ControllerMode controller_mode = standard_mode) {
+  void apply_reactions(
+      ParticleGroupSharedPtr particle_group, double dt,
+      ControllerMode controller_mode = ControllerMode::standard_mode) {
     const size_t cell_count = particle_group->domain->mesh->get_cell_count();
 
     // Ensure that the total rate buffer is flushed before the reactions are
@@ -213,7 +214,7 @@ public:
 
     switch (controller_mode) {
 
-    case semi_dsmc_mode:
+    case ControllerMode::semi_dsmc_mode:
       use_full_weight = true;
 
       break;
@@ -235,7 +236,7 @@ public:
 
         switch (controller_mode) {
 
-        case semi_dsmc_mode: {
+        case ControllerMode::semi_dsmc_mode: {
 
           for (int in_state : in_states) {
             this->reacted_species_groups.emplace(std::make_pair(
@@ -271,7 +272,7 @@ public:
 
       switch (controller_mode) {
 
-      case semi_dsmc_mode: {
+      case ControllerMode::semi_dsmc_mode: {
 
         // marking loop
         auto loop = particle_loop(

--- a/test/unit/test_reaction_controller.cpp
+++ b/test/unit/test_reaction_controller.cpp
@@ -1,5 +1,6 @@
 #include "include/mock_particle_group.hpp"
 #include "include/mock_reactions.hpp"
+#include "reactions_lib/reaction_controller.hpp"
 #include <gtest/gtest.h>
 #include <memory>
 
@@ -582,7 +583,7 @@ TEST(ReactionController, semi_dsmc_test) {
   reaction_controller.add_reaction(test_reaction_2);
 
   auto start_npart = particle_group->get_npart_local();
-  reaction_controller.apply_reactions(particle_group, 1.0, semi_dsmc_mode);
+  reaction_controller.apply_reactions(particle_group, 1.0, ControllerMode::semi_dsmc_mode);
 
   int cell_count = particle_group->domain->mesh->get_cell_count();
   for (int i = 0; i < cell_count; i++) {


### PR DESCRIPTION
Minor PR, moving to using enum instead of setting a member variable to the mode.