### PR TITLE
WIP: Allowing filtering and transformation before reaction kernel application in ReactionController

### DIFF
--- a/src/reactions_lib/reaction_controller.hpp
+++ b/src/reactions_lib/reaction_controller.hpp
@@ -7,7 +7,6 @@
 #include <iostream>
 #include <memory>
 #include <neso_particles.hpp>
-#include <neso_particles/particle_sub_group/particle_sub_group.hpp>
 
 using namespace NESO::Particles;
 
@@ -392,7 +391,7 @@ public:
 
       case ControllerMode::semi_dsmc_mode: {
 
-        //Re-calculate rates
+        // Re-calculate rates
         rate_buffer_zeroer->transform(
             particle_group, i, std::min(i + this->cell_block_size, cell_count));
         for (int r = 0; r < this->reactions.size(); r++) {


### PR DESCRIPTION
Added two new optional arguments to `ReactionController` - `std::vector<std::shared_ptr<MarkingStrategy>> pre_apply_filters` and `std::vector<std::shared_ptr<TransformationStrategy>>  pre_kernel_transforms`. 

The marking strategies are applied immediately, and can be used to restrict the application of the controller to only some particles. Note that these strategies must behave identically on repeated applications, since they are also used to restrict any parent transformation wrappers.

The `pre_transform_kernels` are applied before the first call to `run_rate_loop`. I've split the main loop to enable them to be re-applied in the case of semi-dsmc mode controllers (not relevant for the surface application). 
