### PR TITLE
WIP: Pair reaction data and kernels

### DIFF
--- a/src/reactions/reactions.hpp
+++ b/src/reactions/reactions.hpp
@@ -14,6 +14,7 @@
 #include "../reactions_lib/merge_transformation.hpp"
 #include "../reactions_lib/pair_data_calculator.hpp"
 #include "../reactions_lib/pair_reaction_data.hpp"
+#include "../reactions_lib/pair_reaction_kernels.hpp"
 #include "../reactions_lib/particle_properties_map.hpp"
 #include "../reactions_lib/particle_spec_builder.hpp"
 #include "../reactions_lib/pipeline_data.hpp"

--- a/src/reactions/reactions.hpp
+++ b/src/reactions/reactions.hpp
@@ -12,6 +12,8 @@
 #include "../reactions_lib/data_calculator.hpp"
 #include "../reactions_lib/downsampling_base.hpp"
 #include "../reactions_lib/merge_transformation.hpp"
+#include "../reactions_lib/pair_data_calculator.hpp"
+#include "../reactions_lib/pair_reaction_data.hpp"
 #include "../reactions_lib/particle_properties_map.hpp"
 #include "../reactions_lib/particle_spec_builder.hpp"
 #include "../reactions_lib/pipeline_data.hpp"
@@ -26,6 +28,7 @@
 #include "../reactions_lib/utils.hpp"
 
 #include "../reactions_lib/cross_sections/AMJUEL_fit_cs.hpp"
+#include "../reactions_lib/cross_sections/constant_cs.hpp"
 #include "../reactions_lib/cross_sections/constant_rate_cs.hpp"
 
 #include "../reactions_lib/reaction_data/AMJUEL_1D_data.hpp"
@@ -46,6 +49,8 @@
 #include "../reactions_lib/reaction_data/specular_reflection_data.hpp"
 #include "../reactions_lib/reaction_data/spherical_basis_reflection_data.hpp"
 #include "../reactions_lib/reaction_data/trim_eval_data.hpp"
+
+#include "../reactions_lib/pair_reaction_data/cs_pair_reaction_data.hpp"
 
 #include "../reactions_lib/reaction_kernels/base_cx_kernels.hpp"
 #include "../reactions_lib/reaction_kernels/base_ionisation_kernels.hpp"

--- a/src/reactions_lib/cross_sections/constant_cs.hpp
+++ b/src/reactions_lib/cross_sections/constant_cs.hpp
@@ -1,0 +1,63 @@
+#ifndef REACTIONS_CONSTANT_CS_H
+#define REACTIONS_CONSTANT_CS_H
+#include "../reaction_data.hpp"
+#include <limits>
+#include <neso_particles.hpp>
+
+using namespace NESO::Particles;
+namespace VANTAGE::Reactions {
+
+/**
+ * @brief A constant cross section. The rate is unbounded, so a default maximum
+ * velocity needs to be suplied. NOTE: Ideally, the default maximum rate call
+ * wouldn't be used.
+ */
+struct ConstantCrossSection : public AbstractCrossSection {
+
+  ConstantCrossSection() = default;
+  /**
+   * @brief Constructor for ConstantCrossSection.
+   *
+   * @param constant_sigma Constant collision rate
+   * @param default_max_vel The maximum allowed relative velocity for the
+   * get_max_rate_val() call
+   */
+  ConstantCrossSection(REAL constant_sigma, REAL default_max_vel)
+      : constant_sigma(constant_sigma), default_max_vel(default_max_vel) {};
+
+  /**
+   * @brief Returns the cross-section value at given relative velocity
+   *
+   * @param relative_vel Relative velocity of projectile and target
+   * @return REAL-valued cross-section
+   */
+  REAL get_value_at(const REAL &relative_vel) const {
+    return this->constant_sigma;
+  };
+
+  /**
+   * @brief Returns maximum value of the rate sigma*v of for this cross-section.
+   *
+   * @return REAL-valued constant
+   */
+  REAL get_max_rate_val() const {
+    return this->constant_sigma * this->default_max_vel;
+  };
+
+  /**
+   * @brief Get the greedy maximum value of sigma*v_r.
+   *
+   * @param relative_vel Magnitude of relative velocity of the projectile and
+   * target
+   * @return REAL-valued maximum rate
+   */
+  REAL get_max_rate_val(REAL relative_vel) const {
+    return this->constant_sigma * relative_vel;
+  };
+
+private:
+  REAL constant_sigma;
+  REAL default_max_vel;
+};
+}; // namespace VANTAGE::Reactions
+#endif

--- a/src/reactions_lib/cross_sections/constant_rate_cs.hpp
+++ b/src/reactions_lib/cross_sections/constant_rate_cs.hpp
@@ -35,7 +35,6 @@ struct ConstantRateCrossSection : public AbstractCrossSection {
 
   /**
    * @brief Returns maximum value of the rate sigma*v of for this cross-section.
-   * This is constant in this class.
    *
    * @return REAL-valued constant (plus floating point error to account for
    * potential use in explicit rejection methods).

--- a/src/reactions_lib/data_calculator.hpp
+++ b/src/reactions_lib/data_calculator.hpp
@@ -73,8 +73,10 @@ struct DataCalculator : public AbstractDataCalculator {
    * @param buffer NDLocalArray buffer - size should conform to the stored
    * ReactionData tuple size
    * @param particle_sub_group Particle subgroup used to fill out the buffer
-   * @param cell_idx Cell index for which to invoke the corresponding particle
-   * loops
+   * @param cell_idx_start Cell index from which to invoke the corresponding
+   * particle loops
+   * @param cell_idx_end Cell index to which to invoke the corresponding
+   * particle loops
    */
   void fill_buffer(const NDLocalArraySharedPtr<REAL, 2> &buffer,
                    ParticleSubGroupSharedPtr particle_sub_group,

--- a/src/reactions_lib/pair_data_calculator.hpp
+++ b/src/reactions_lib/pair_data_calculator.hpp
@@ -54,17 +54,18 @@ struct PairDataCalculator : public AbstractPairDataCalculator {
           size_t dat_idx = 0u;
           (
               [&] {
+                auto arg_pack = args.get_arg_pack();
                 this->data_loop_int_syms_a.push_back(
-                    args.get_required_int_sym_vector_a());
+                    arg_pack.required_int_props_a.to_sym_vector());
 
                 this->data_loop_real_syms_a.push_back(
-                    args.get_required_real_sym_vector_a());
+                    arg_pack.required_real_props_a.to_sym_vector());
 
                 this->data_loop_int_syms_b.push_back(
-                    args.get_required_int_sym_vector_b());
+                    arg_pack.required_int_props_b.to_sym_vector());
 
                 this->data_loop_real_syms_b.push_back(
-                    args.get_required_real_sym_vector_b());
+                    arg_pack.required_real_props_b.to_sym_vector());
                 dat_idx++;
               }(),
               ...);
@@ -107,10 +108,11 @@ struct PairDataCalculator : public AbstractPairDataCalculator {
                         auto req_real_props_a, auto req_int_props_b,
                         auto req_real_props_b, auto buffer, auto kernel) {
                       INT current_count = pair_index.get_loop_linear_index();
+                      auto accessors = PairReactionDataAccessors(
+                          pair_index, req_int_props_a, req_real_props_a,
+                          req_int_props_b, req_real_props_b);
                       std::array<REAL, data_dim> rate =
-                          reaction_data_on_device.calc_data(
-                              pair_index, req_int_props_a, req_real_props_a,
-                              req_int_props_b, req_real_props_b, kernel);
+                          reaction_data_on_device.calc_data(accessors, kernel);
                       for (auto i = 0; i < data_dim; i++) {
                         buffer.at(current_count, dat_dim_idx + i) = rate[i];
                       }

--- a/src/reactions_lib/pair_data_calculator.hpp
+++ b/src/reactions_lib/pair_data_calculator.hpp
@@ -1,0 +1,170 @@
+#ifndef REACTIONS_PAIR_DATA_CALCULATOR_H
+#define REACTIONS_PAIR_DATA_CALCULATOR_H
+#include "pair_reaction_data.hpp"
+#include "utils.hpp"
+#include <neso_particles.hpp>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+using namespace NESO::Particles;
+
+namespace VANTAGE::Reactions {
+
+/**
+ * @brief A dummy struct to derive PairDataCalculator froe
+ * for the purposes of type-checking of PairDataCalculatoo (when it's passed as
+ * a typename template parameter - see LinearReactionBase)
+ */
+struct AbstractPairDataCalculator {
+  virtual ~AbstractPairDataCalculator() = default;
+};
+
+/**
+ * @brief A static container class for PairReactionData objects
+ *
+ * @tparam DATATYPE PairReactionData types
+ */
+template <typename... DATATYPE>
+struct PairDataCalculator : public AbstractPairDataCalculator {
+
+  /**
+   * @brief Constructor for PairDataCalculator.
+   *
+   * @param data List of PairReactionData objects (as multiple arguments).
+   */
+  PairDataCalculator(DATATYPE... data) : data(std::make_tuple(data...)) {
+
+    size_t type_check_counter = 0u;
+    (
+        [&] {
+          static_assert(
+              std::is_base_of_v<
+                  PairReactionDataBase<
+                      typename decltype(data)::ON_DEVICE_OBJ_TYPE,
+                      data.get_dim(), typename decltype(data)::RNG_KERNEL_TYPE>,
+                  decltype(data)>,
+              "DATATYPE provided is not derived from ReactionDataBase.");
+          type_check_counter++;
+        }(),
+        ...);
+
+    std::apply(
+        [&](auto &&...args) {
+          size_t dat_idx = 0u;
+          (
+              [&] {
+                this->data_loop_int_syms_a.push_back(
+                    args.get_required_int_sym_vector_a());
+
+                this->data_loop_real_syms_a.push_back(
+                    args.get_required_real_sym_vector_a());
+
+                this->data_loop_int_syms_b.push_back(
+                    args.get_required_int_sym_vector_b());
+
+                this->data_loop_real_syms_b.push_back(
+                    args.get_required_real_sym_vector_b());
+                dat_idx++;
+              }(),
+              ...);
+        },
+        this->data);
+  }
+
+  /**
+   * @brief Fills an NDLocalArray buffer by invoking the stored PairReactionData
+   * objects for a given cell index
+   *
+   * @param buffer NDLocalArray buffer - size should conform to the stored
+   * PairReactionData tuple size
+   * @param pair_list Particle pair list used to fill out the buffer
+   * @param cell_idx_start Cell index from which to invoke the corresponding
+   * particle loops
+   * @param cell_idx_end Cell index to which to invoke the corresponding
+   * particle loops
+   */
+  template <typename TARGET, typename PAIR_LIST>
+  void fill_buffer(const NDLocalArraySharedPtr<REAL, 2> &buffer,
+                   CellwisePairListAbsolute<TARGET, PAIR_LIST> &pair_list,
+                   INT cell_idx_start, INT cell_idx_end) {
+    NESOASSERT(buffer->index.shape[1] == this->get_data_size(),
+               "Buffer size in fill_buffer does not correspond to the number "
+               "data calculation objects.");
+    std::apply(
+        [&](auto &&...args) {
+          size_t dat_idx = 0u;
+          size_t dat_dim_idx = 0u;
+          (
+              [&] {
+                auto reaction_data_on_device = args.get_on_device_obj();
+                // Maybe make into a vector of loop shared_ptrs and use submit
+                // instead of execute
+                constexpr auto data_dim = reaction_data_on_device.get_dim();
+                auto loop = particle_pair_loop(
+                    "pair_data_calc_loop", {pair_list},
+                    [=](auto pair_index, auto req_int_props_a,
+                        auto req_real_props_a, auto req_int_props_b,
+                        auto req_real_props_b, auto buffer, auto kernel) {
+                      INT current_count = pair_index.get_loop_linear_index();
+                      std::array<REAL, data_dim> rate =
+                          reaction_data_on_device.calc_data(
+                              pair_index, req_int_props_a, req_real_props_a,
+                              req_int_props_b, req_real_props_b, kernel);
+                      for (auto i = 0; i < data_dim; i++) {
+                        buffer.at(current_count, dat_dim_idx + i) = rate[i];
+                      }
+                    },
+                    Access::read(ParticlePairLoopIndex{}),
+                    Access::A(Access::write(sym_vector<INT>(
+                        pair_list.A, this->data_loop_int_syms_a[dat_idx]))),
+                    Access::A(Access::read(sym_vector<REAL>(
+                        pair_list.A, this->data_loop_real_syms_a[dat_idx]))),
+                    Access::B(Access::write(sym_vector<INT>(
+                        pair_list.B, this->data_loop_int_syms_b[dat_idx]))),
+                    Access::B(Access::read(sym_vector<REAL>(
+                        pair_list.B, this->data_loop_real_syms_b[dat_idx]))),
+                    Access::write(buffer), Access::read(args.get_rng_kernel()));
+
+                loop->execute(cell_idx_start, cell_idx_end);
+                dat_idx++;
+                dat_dim_idx += data_dim;
+              }(),
+              ...);
+        },
+        this->data);
+  }
+
+  /**
+   * @brief Getter for the total number of dimensions of the objects in the
+   * ReactionData tuple
+   */
+  size_t get_data_size() const {
+    size_t dat_idx = 0u;
+    std::apply(
+        [&](auto &&...args) {
+          (
+              [&] {
+                const auto data_dim = args.get_dim();
+                dat_idx += data_dim;
+              }(),
+              ...);
+        },
+        this->data);
+    return dat_idx;
+  }
+
+  /**
+   * @brief Getter of the total number of objects in the ReactionData tuple
+   */
+  size_t get_data_tuple_size() const { return std::size(this->data); }
+
+private:
+  std::tuple<DATATYPE...> data;
+  std::vector<std::vector<Sym<INT>>> data_loop_int_syms_a;
+  std::vector<std::vector<Sym<REAL>>> data_loop_real_syms_a;
+  std::vector<std::vector<Sym<INT>>> data_loop_int_syms_b;
+  std::vector<std::vector<Sym<REAL>>> data_loop_real_syms_b;
+};
+} // namespace VANTAGE::Reactions
+#endif

--- a/src/reactions_lib/pair_reaction_data.hpp
+++ b/src/reactions_lib/pair_reaction_data.hpp
@@ -1,6 +1,6 @@
 #ifndef REACTIONS_PAIR_REACTION_DATA_H
 #define REACTIONS_PAIR_REACTION_DATA_H
-#include "reaction_data.hpp"
+#include "reaction_data_abstract.hpp"
 #include "reaction_kernel_pre_reqs.hpp"
 #include <memory>
 #include <neso_particles.hpp>
@@ -9,6 +9,39 @@
 
 using namespace NESO::Particles;
 namespace VANTAGE::Reactions {
+
+struct PairReactionDataAccessors {
+
+  PairReactionDataAccessors(Access::PairLoopIndex::Read index,
+                            Access::SymVector::Write<INT> req_int_props_a,
+                            Access::SymVector::Read<REAL> req_real_props_a,
+                            Access::SymVector::Write<INT> req_int_props_b,
+                            Access::SymVector::Read<REAL> req_real_props_b)
+      : index(index), req_int_props_a(req_int_props_a),
+        req_real_props_a(req_real_props_a), req_int_props_b(req_int_props_b),
+        req_real_props_b(req_real_props_b) {};
+  Access::PairLoopIndex::Read index;
+  Access::SymVector::Write<INT> req_int_props_a;
+  Access::SymVector::Read<REAL> req_real_props_a;
+  Access::SymVector::Write<INT> req_int_props_b;
+  Access::SymVector::Read<REAL> req_real_props_b;
+};
+
+struct PairReactionDataArgumentPack {
+
+  PairReactionDataArgumentPack(ArgumentNameSet<INT> req_int_props_a,
+                               ArgumentNameSet<REAL> req_real_props_a,
+                               ArgumentNameSet<INT> req_int_props_b,
+                               ArgumentNameSet<REAL> req_real_props_b)
+      : required_int_props_a(req_int_props_a),
+        required_real_props_a(req_real_props_a),
+        required_int_props_b(req_int_props_b),
+        required_real_props_b(req_real_props_b) {};
+  ArgumentNameSet<INT> required_int_props_a;
+  ArgumentNameSet<REAL> required_real_props_a;
+  ArgumentNameSet<INT> required_int_props_b;
+  ArgumentNameSet<REAL> required_real_props_b;
+};
 
 using DEFAULT_RNG_KERNEL = NullKernelRNG<REAL>;
 
@@ -24,46 +57,9 @@ using DEFAULT_RNG_KERNEL = NullKernelRNG<REAL>;
  */
 template <typename ON_DEVICE_TYPE, size_t dim = 1,
           typename RNG_TYPE = DEFAULT_RNG_KERNEL, size_t input_dim = 0>
-struct PairReactionDataBase {
-
-  using RNG_KERNEL_TYPE = RNG_TYPE;
-  using ON_DEVICE_OBJ_TYPE = ON_DEVICE_TYPE;
-  static const size_t DIM = dim;
-  static const size_t INPUT_DIM = input_dim;
-
-  /**
-   * @brief Validate that the on-device type defines calc_data with the
-   * parameter signature and return type expected by this host base class.
-   */
-  static constexpr bool validate_on_device_type() {
-    if constexpr (ON_DEVICE_TYPE::INPUT_DIM > 0) {
-      using input_t = const std::array<typename ON_DEVICE_TYPE::INPUT_TYPE,
-                                       ON_DEVICE_TYPE::INPUT_DIM> &;
-
-      static_assert(
-          is_calc_data_callable_v<ON_DEVICE_TYPE, input_t,
-                                  const Access::PairLoopIndex::Read &,
-                                  const Access::SymVector::Write<INT> &,
-                                  const Access::SymVector::Read<REAL> &,
-                                  const Access::SymVector::Write<INT> &,
-                                  const Access::SymVector::Read<REAL> &,
-                                  typename RNG_TYPE::KernelType &>,
-          "ON_DEVICE_TYPE::calc_data parameter signature mismatch");
-
-      static_assert(check_calc_data_return_type<
-                        ON_DEVICE_TYPE,
-                        std::array<typename ON_DEVICE_TYPE::VALUE_TYPE,
-                                   ON_DEVICE_TYPE::DIM>,
-                        input_t, const Access::PairLoopIndex::Read &,
-                        const Access::SymVector::Write<INT> &,
-                        const Access::SymVector::Read<REAL> &,
-                        const Access::SymVector::Write<INT> &,
-                        const Access::SymVector::Read<REAL> &,
-                        typename RNG_TYPE::KernelType &>(),
-                    "ON_DEVICE_TYPE::calc_data return type mismatch");
-    }
-    return true;
-  }
+struct PairReactionDataBase
+    : AbstractReactionData<ON_DEVICE_TYPE, PairReactionDataArgumentPack, dim,
+                           RNG_TYPE, input_dim> {
 
   /**
    * @brief Constructor for PairReactionDataBase.
@@ -90,19 +86,14 @@ struct PairReactionDataBase {
       Properties<INT> required_int_props_b,
       Properties<REAL> required_real_props_b,
       std::map<int, std::string> properties_map = get_default_map())
-      : required_int_props_a(
-            ArgumentNameSet(required_int_props_a, properties_map)),
-        required_real_props_a(
-            ArgumentNameSet(required_real_props_a, properties_map)),
-        required_int_props_b(
-            ArgumentNameSet(required_int_props_b, properties_map)),
-        required_real_props_b(
-            ArgumentNameSet(required_real_props_b, properties_map)),
-        properties_map(properties_map) {
-
-    static_assert(validate_on_device_type());
-    this->rng_kernel = std::make_shared<RNG_TYPE>();
-  }
+      : AbstractReactionData<ON_DEVICE_TYPE, PairReactionDataArgumentPack, dim,
+                             RNG_TYPE, input_dim>(
+            PairReactionDataArgumentPack(
+                ArgumentNameSet(required_int_props_a, properties_map),
+                ArgumentNameSet(required_real_props_a, properties_map),
+                ArgumentNameSet(required_int_props_b, properties_map),
+                ArgumentNameSet(required_real_props_b, properties_map)),
+            properties_map) {}
 
   /**
    * \overload
@@ -174,149 +165,6 @@ struct PairReactionDataBase {
       : PairReactionDataBase(required_int_props, required_real_props,
                              required_int_props, required_real_props,
                              properties_map) {}
-  /**
-   * @brief Return all required integer properties for the first particle
-   *
-   */
-  ArgumentNameSet<INT> get_required_int_props_a() {
-    return this->required_int_props_a;
-  }
-
-  /**
-   * @brief Setter for required integer properties of the first particle
-   *
-   * @param props ArgumentNameSet to use
-   */
-  void set_required_int_props_a(const ArgumentNameSet<INT> &props) {
-    this->required_int_props_a = props;
-    this->index_on_device_object();
-  }
-
-  /**
-   * @brief Return all required integer properties for the second particle
-   *
-   */
-  ArgumentNameSet<INT> get_required_int_props_b() {
-    return this->required_int_props_b;
-  }
-
-  /**
-   * @brief Setter for required integer properties of the second particle
-   *
-   * @param props ArgumentNameSet to use
-   */
-  void set_required_int_props_b(const ArgumentNameSet<INT> &props) {
-    this->required_int_props_b = props;
-    this->index_on_device_object();
-  }
-
-  /**
-   * @brief Return all required integer properties of the first particle as a
-   * vector of Syms
-   *
-   */
-  std::vector<Sym<INT>> get_required_int_sym_vector_a() {
-    return this->required_int_props_a.to_sym_vector();
-  }
-
-  /**
-   * @brief Return all required integer properties of the second particle as a
-   * vector of Syms
-   *
-   */
-  std::vector<Sym<INT>> get_required_int_sym_vector_b() {
-    return this->required_int_props_b.to_sym_vector();
-  }
-
-  /**
-   * @brief Return all required real properties of the first particle
-   *
-   */
-  ArgumentNameSet<REAL> get_required_real_props_a() {
-    return this->required_real_props_a;
-  }
-
-  /**
-   * @brief Return all required real properties of the first particle as a
-   * vector of Syms
-   *
-   */
-  std::vector<Sym<REAL>> get_required_real_sym_vector_a() {
-    return this->required_real_props_a.to_sym_vector();
-  }
-
-  /**
-   * @brief Setter for required real properties of the first particle
-   *
-   * @param props ArgumentNameSet to use
-   */
-  void set_required_real_props_a(const ArgumentNameSet<REAL> &props) {
-    this->required_real_props_a = props;
-    this->index_on_device_object();
-  }
-
-  /**
-   * @brief Return all required real properties of the second particle
-   *
-   */
-  ArgumentNameSet<REAL> get_required_real_props_b() {
-    return this->required_real_props_b;
-  }
-
-  /**
-   * @brief Return all required real properties of the second particle as a
-   * vector of Syms
-   *
-   */
-  std::vector<Sym<REAL>> get_required_real_sym_vector_b() {
-    return this->required_real_props_b.to_sym_vector();
-  }
-
-  /**
-   * @brief Setter for required real properties of the second particle
-   *
-   * @param props ArgumentNameSet to use
-   */
-  void set_required_real_props_b(const ArgumentNameSet<REAL> &props) {
-    this->required_real_props_b = props;
-    this->index_on_device_object();
-  }
-
-  void set_rng_kernel(std::shared_ptr<RNG_TYPE> rng_kernel) {
-    this->rng_kernel = rng_kernel;
-  }
-
-  std::shared_ptr<RNG_TYPE> get_rng_kernel() { return this->rng_kernel; }
-
-  static constexpr size_t get_dim() { return dim; }
-
-  virtual ~PairReactionDataBase() = default;
-
-  /**
-   * @brief To be implemented by each derived class in order to handle required
-   * property indexing on the on-device object
-   */
-  virtual void index_on_device_object() {};
-
-  /**
-   * @brief Getter for the SYCL device-specific
-   * struct.
-   */
-  const ON_DEVICE_TYPE &get_on_device_obj() {
-
-    NESOASSERT(this->on_device_obj.has_value(),
-               "on_device_obj in PairReactionDataBase not initialised");
-    return this->on_device_obj.value();
-  }
-
-protected:
-  std::optional<ON_DEVICE_TYPE> on_device_obj;
-  ArgumentNameSet<INT> required_int_props_a;
-  ArgumentNameSet<REAL> required_real_props_a;
-  ArgumentNameSet<INT> required_int_props_b;
-  ArgumentNameSet<REAL> required_real_props_b;
-  std::shared_ptr<RNG_TYPE> rng_kernel;
-  std::map<int, std::string> properties_map;
 };
 
 /**
@@ -334,61 +182,9 @@ protected:
 template <size_t dim = 1, typename RNG_TYPE = DEFAULT_RNG_KERNEL,
           size_t input_dim = 0, typename VAL_TYPE = REAL,
           typename IN_TYPE = REAL>
-struct PairReactionDataBaseOnDevice {
-  using RNG_KERNEL_TYPE = RNG_TYPE;
-  using VALUE_TYPE = VAL_TYPE;
-  using INPUT_TYPE = IN_TYPE;
-  static const size_t DIM = dim;
-  static const size_t INPUT_DIM = input_dim;
-
-  PairReactionDataBaseOnDevice() = default;
-
-  /**
-   * @brief Function to calculate the reaction data.
-   *
-   * @param index Read-only accessor to a pair loop index for a ParticlePairLoop
-   * inside which calc_data is called. Access using
-   * index.get_loop_linear_index().
-   * @param req_int_props_a Vector of symbols for integer-valued properties of
-   * the first particle that need to be used for the reaction data calculation.
-   * @param req_real_props_a Vector of symbols for real-valued properties of the
-   * first particle that need to be used for the reaction data calculation.
-   * @param req_int_props_b Vector of symbols for integer-valued properties of
-   * the second particle that need to be used for the reaction data calculation.
-   * @param req_real_props_b Vector of symbols for real-valued properties of the
-   * second particle that need to be used for the reaction data calculation.
-   * @param rng_kernel The random number generator kernel potentially used in
-   * the calculation
-   *
-   * @return A REAL-valued array of size dim containing the calculated reaction
-   * rate.
-   */
-  template <std::size_t D = INPUT_DIM,
-            std::enable_if_t<(D == 0) && D == INPUT_DIM, int> = 0>
-  std::array<VAL_TYPE, dim>
-  calc_data(const Access::PairLoopIndex::Read &index,
-            const Access::SymVector::Write<INT> &req_int_props_a,
-            const Access::SymVector::Read<REAL> &req_real_props_a,
-            const Access::SymVector::Write<INT> &req_int_props_b,
-            const Access::SymVector::Read<REAL> &req_real_props_b,
-            typename RNG_TYPE::KernelType &rng_kernel) const {
-    return std::array<REAL, dim>{0.0};
-  }
-
-  template <std::size_t D = INPUT_DIM,
-            std::enable_if_t<(D > 0) && D == INPUT_DIM, int> = 0>
-  std::array<VAL_TYPE, dim>
-  calc_data(const std::array<IN_TYPE, INPUT_DIM> &input,
-            const Access::PairLoopIndex::Read &index,
-            const Access::SymVector::Write<INT> &req_int_props_a,
-            const Access::SymVector::Read<REAL> &req_real_props_a,
-            const Access::SymVector::Write<INT> &req_int_props_b,
-            const Access::SymVector::Read<REAL> &req_real_props_b,
-            typename RNG_TYPE::KernelType &rng_kernel) const {
-    return std::array<REAL, dim>{0.0};
-  }
-  static constexpr size_t get_dim() { return dim; }
-};
+struct PairReactionDataBaseOnDevice
+    : AbstractReactionDataOnDevice<PairReactionDataAccessors, dim, RNG_TYPE,
+                                   input_dim, VAL_TYPE, IN_TYPE> {};
 
 }; // namespace VANTAGE::Reactions
 #endif

--- a/src/reactions_lib/pair_reaction_data.hpp
+++ b/src/reactions_lib/pair_reaction_data.hpp
@@ -48,18 +48,19 @@ using DEFAULT_RNG_KERNEL = NullKernelRNG<REAL>;
 /**
  * @brief Base pair reaction data object.
  *
- * @tparam ON_DEVICE_TYPE Type of the on-device object
+ * @tparam ON_DEVICE_T Type of the on-device object
  * @tparam dim Used to set the size of the array that calc_data returns
  * (Optional).
- * @tparam RNG_TYPE Sets the type of RNG that is used for sampling (Optional).
+ * @tparam RNG_KERNEL_T Sets the type of RNG that is used for sampling
+ * (Optional).
  * @tparam input_dim The dimension of the input array (Optional, defaults to 0,
  * not defining the corresponding calc_data)
  */
-template <typename ON_DEVICE_TYPE, size_t dim = 1,
-          typename RNG_TYPE = DEFAULT_RNG_KERNEL, size_t input_dim = 0>
+template <typename ON_DEVICE_T, size_t dim = 1,
+          typename RNG_KERNEL_T = DEFAULT_RNG_KERNEL, size_t input_dim = 0>
 struct PairReactionDataBase
-    : AbstractReactionData<ON_DEVICE_TYPE, PairReactionDataArgumentPack, dim,
-                           RNG_TYPE, input_dim> {
+    : AbstractReactionData<ON_DEVICE_T, PairReactionDataArgumentPack, dim,
+                           RNG_KERNEL_T, input_dim> {
 
   /**
    * @brief Constructor for PairReactionDataBase.
@@ -86,8 +87,8 @@ struct PairReactionDataBase
       Properties<INT> required_int_props_b,
       Properties<REAL> required_real_props_b,
       std::map<int, std::string> properties_map = get_default_map())
-      : AbstractReactionData<ON_DEVICE_TYPE, PairReactionDataArgumentPack, dim,
-                             RNG_TYPE, input_dim>(
+      : AbstractReactionData<ON_DEVICE_T, PairReactionDataArgumentPack, dim,
+                             RNG_KERNEL_T, input_dim>(
             PairReactionDataArgumentPack(
                 ArgumentNameSet(required_int_props_a, properties_map),
                 ArgumentNameSet(required_real_props_a, properties_map),
@@ -172,19 +173,20 @@ struct PairReactionDataBase
  *
  * @tparam dim Used to set the size of the array that calc_data returns
  * (Optional).
- * @tparam RNG_TYPE Sets the type of RNG that is used for sampling (Optional).
+ * @tparam RNG_KERNEL_T Sets the type of RNG that is used for sampling
+ * (Optional).
  * @tparam input_dim The dimension of the optional input array (for use in
  * pipelines) (Optional, default 0)
- * @tparam VAL_TYPE Return type of this objects calc_data routine (Optional,
+ * @tparam VALUE_T Return type of this objects calc_data routine (Optional,
  * default REAL)
- * @tparam IN_TYPE Input type of array required by this object (if input_dim >0)
+ * @tparam INPUT_T Input type of array required by this object (if input_dim >0)
  */
-template <size_t dim = 1, typename RNG_TYPE = DEFAULT_RNG_KERNEL,
-          size_t input_dim = 0, typename VAL_TYPE = REAL,
-          typename IN_TYPE = REAL>
+template <size_t dim = 1, typename RNG_KERNEL_T = DEFAULT_RNG_KERNEL,
+          size_t input_dim = 0, typename VALUE_T = REAL,
+          typename INPUT_T = REAL>
 struct PairReactionDataBaseOnDevice
-    : AbstractReactionDataOnDevice<PairReactionDataAccessors, dim, RNG_TYPE,
-                                   input_dim, VAL_TYPE, IN_TYPE> {};
+    : AbstractReactionDataOnDevice<PairReactionDataAccessors, dim, RNG_KERNEL_T,
+                                   input_dim, VALUE_T, INPUT_T> {};
 
 }; // namespace VANTAGE::Reactions
 #endif

--- a/src/reactions_lib/pair_reaction_data.hpp
+++ b/src/reactions_lib/pair_reaction_data.hpp
@@ -1,0 +1,394 @@
+#ifndef REACTIONS_PAIR_REACTION_DATA_H
+#define REACTIONS_PAIR_REACTION_DATA_H
+#include "reaction_data.hpp"
+#include "reaction_kernel_pre_reqs.hpp"
+#include <memory>
+#include <neso_particles.hpp>
+#include <type_traits>
+#include <utility>
+
+using namespace NESO::Particles;
+namespace VANTAGE::Reactions {
+
+using DEFAULT_RNG_KERNEL = NullKernelRNG<REAL>;
+
+/**
+ * @brief Base pair reaction data object.
+ *
+ * @tparam ON_DEVICE_TYPE Type of the on-device object
+ * @tparam dim Used to set the size of the array that calc_data returns
+ * (Optional).
+ * @tparam RNG_TYPE Sets the type of RNG that is used for sampling (Optional).
+ * @tparam input_dim The dimension of the input array (Optional, defaults to 0,
+ * not defining the corresponding calc_data)
+ */
+template <typename ON_DEVICE_TYPE, size_t dim = 1,
+          typename RNG_TYPE = DEFAULT_RNG_KERNEL, size_t input_dim = 0>
+struct PairReactionDataBase {
+
+  using RNG_KERNEL_TYPE = RNG_TYPE;
+  using ON_DEVICE_OBJ_TYPE = ON_DEVICE_TYPE;
+  static const size_t DIM = dim;
+  static const size_t INPUT_DIM = input_dim;
+
+  /**
+   * @brief Validate that the on-device type defines calc_data with the
+   * parameter signature and return type expected by this host base class.
+   */
+  static constexpr bool validate_on_device_type() {
+    if constexpr (ON_DEVICE_TYPE::INPUT_DIM > 0) {
+      using input_t = const std::array<typename ON_DEVICE_TYPE::INPUT_TYPE,
+                                       ON_DEVICE_TYPE::INPUT_DIM> &;
+
+      static_assert(
+          is_calc_data_callable_v<ON_DEVICE_TYPE, input_t,
+                                  const Access::PairLoopIndex::Read &,
+                                  const Access::SymVector::Write<INT> &,
+                                  const Access::SymVector::Read<REAL> &,
+                                  const Access::SymVector::Write<INT> &,
+                                  const Access::SymVector::Read<REAL> &,
+                                  typename RNG_TYPE::KernelType &>,
+          "ON_DEVICE_TYPE::calc_data parameter signature mismatch");
+
+      static_assert(check_calc_data_return_type<
+                        ON_DEVICE_TYPE,
+                        std::array<typename ON_DEVICE_TYPE::VALUE_TYPE,
+                                   ON_DEVICE_TYPE::DIM>,
+                        input_t, const Access::PairLoopIndex::Read &,
+                        const Access::SymVector::Write<INT> &,
+                        const Access::SymVector::Read<REAL> &,
+                        const Access::SymVector::Write<INT> &,
+                        const Access::SymVector::Read<REAL> &,
+                        typename RNG_TYPE::KernelType &>(),
+                    "ON_DEVICE_TYPE::calc_data return type mismatch");
+    }
+    return true;
+  }
+
+  /**
+   * @brief Constructor for PairReactionDataBase.
+   *
+   * @param required_int_props_a Properties<INT> object containing information
+   * regarding the required INT-based properties of the first particle for the
+   * reaction data.
+   * @param required_real_props_a Properties<REAL> object containing information
+   * regarding the required REAL-based properties of the first particle for the
+   * reaction data.
+   * @param required_int_props_b Properties<INT> object containing information
+   * regarding the required INT-based properties of the second particle for the
+   * reaction data.
+   * @param required_real_props_b Properties<REAL> object containing information
+   * regarding the required REAL-based properties of the second particle for the
+   * reaction data.
+   * @param properties_map (Optional) A std::map<int, std::string> object to be
+   * used when remapping property names (in get_required_real_props(...) and
+   * get_required_int_props(...)).
+   */
+  PairReactionDataBase(
+      Properties<INT> required_int_props_a,
+      Properties<REAL> required_real_props_a,
+      Properties<INT> required_int_props_b,
+      Properties<REAL> required_real_props_b,
+      std::map<int, std::string> properties_map = get_default_map())
+      : required_int_props_a(
+            ArgumentNameSet(required_int_props_a, properties_map)),
+        required_real_props_a(
+            ArgumentNameSet(required_real_props_a, properties_map)),
+        required_int_props_b(
+            ArgumentNameSet(required_int_props_b, properties_map)),
+        required_real_props_b(
+            ArgumentNameSet(required_real_props_b, properties_map)),
+        properties_map(properties_map) {
+
+    static_assert(validate_on_device_type());
+    this->rng_kernel = std::make_shared<RNG_TYPE>();
+  }
+
+  /**
+   * \overload
+   * @brief Constructor for PairReactionDataBase that sets no required
+   * properties.
+   *
+   * @param properties_map (Optional) A std::map<int, std::string> object to be
+   * used when remapping property names (in get_required_real_props(...) and
+   * get_required_int_props(...)).
+   */
+  PairReactionDataBase(
+      std::map<int, std::string> properties_map = get_default_map())
+      : PairReactionDataBase(Properties<INT>(), Properties<REAL>(),
+                             Properties<INT>(), Properties<REAL>(),
+                             properties_map) {}
+
+  /**
+   * \overload
+   * @brief Constructor for PairReactionDataBase that sets only required int
+   * properties that are the same for both particles.
+   *
+   * @param required_int_props Properties<INT> object containing information
+   * regarding the required INT-based properties for the reaction data.
+   * @param properties_map (Optional) A std::map<int, std::string> object to be
+   * used when remapping property names (in get_required_real_props(...) and
+   * get_required_int_props(...)).
+   */
+  PairReactionDataBase(
+      Properties<INT> required_int_props,
+      std::map<int, std::string> properties_map = get_default_map())
+      : PairReactionDataBase(required_int_props, Properties<REAL>(),
+                             required_int_props, Properties<REAL>(),
+                             properties_map) {}
+
+  /**
+   * \overload
+   * @brief Constructor for PairReactionDataBase that sets only required real
+   * properties that are the same for both particles.
+   *
+   * @param required_real_props Properties<REAL> object containing information
+   * regarding the required REAL-based properties for the reaction data.
+   * @param properties_map (Optional) A std::map<int, std::string> object to be
+   * used when remapping property names (in get_required_real_props(...) and
+   * get_required_int_props(...)).
+   */
+  PairReactionDataBase(
+      Properties<REAL> required_real_props,
+      std::map<int, std::string> properties_map = get_default_map())
+      : PairReactionDataBase(Properties<INT>(), required_real_props,
+                             Properties<INT>(), required_real_props,
+                             properties_map) {}
+
+  /**
+   * \overload
+   * @brief Constructor for PairReactionDataBase that sets required int and
+   * real properties, same for both particles.
+   *
+   * @param required_int_props Properties<INT> object containing information
+   * regarding the required INT-based properties for the reaction data.
+   * @param required_real_props Properties<REAL> object containing information
+   * regarding the required REAL-based properties for the reaction data.
+   * @param properties_map (Optional) A std::map<int, std::string> object to be
+   * used when remapping property names (in get_required_real_props(...) and
+   * get_required_int_props(...)).
+   */
+  PairReactionDataBase(
+      Properties<INT> required_int_props, Properties<REAL> required_real_props,
+      std::map<int, std::string> properties_map = get_default_map())
+      : PairReactionDataBase(required_int_props, required_real_props,
+                             required_int_props, required_real_props,
+                             properties_map) {}
+  /**
+   * @brief Return all required integer properties for the first particle
+   *
+   */
+  ArgumentNameSet<INT> get_required_int_props_a() {
+    return this->required_int_props_a;
+  }
+
+  /**
+   * @brief Setter for required integer properties of the first particle
+   *
+   * @param props ArgumentNameSet to use
+   */
+  void set_required_int_props_a(const ArgumentNameSet<INT> &props) {
+    this->required_int_props_a = props;
+    this->index_on_device_object();
+  }
+
+  /**
+   * @brief Return all required integer properties for the second particle
+   *
+   */
+  ArgumentNameSet<INT> get_required_int_props_b() {
+    return this->required_int_props_b;
+  }
+
+  /**
+   * @brief Setter for required integer properties of the second particle
+   *
+   * @param props ArgumentNameSet to use
+   */
+  void set_required_int_props_b(const ArgumentNameSet<INT> &props) {
+    this->required_int_props_b = props;
+    this->index_on_device_object();
+  }
+
+  /**
+   * @brief Return all required integer properties of the first particle as a
+   * vector of Syms
+   *
+   */
+  std::vector<Sym<INT>> get_required_int_sym_vector_a() {
+    return this->required_int_props_a.to_sym_vector();
+  }
+
+  /**
+   * @brief Return all required integer properties of the second particle as a
+   * vector of Syms
+   *
+   */
+  std::vector<Sym<INT>> get_required_int_sym_vector_b() {
+    return this->required_int_props_b.to_sym_vector();
+  }
+
+  /**
+   * @brief Return all required real properties of the first particle
+   *
+   */
+  ArgumentNameSet<REAL> get_required_real_props_a() {
+    return this->required_real_props_a;
+  }
+
+  /**
+   * @brief Return all required real properties of the first particle as a
+   * vector of Syms
+   *
+   */
+  std::vector<Sym<REAL>> get_required_real_sym_vector_a() {
+    return this->required_real_props_a.to_sym_vector();
+  }
+
+  /**
+   * @brief Setter for required real properties of the first particle
+   *
+   * @param props ArgumentNameSet to use
+   */
+  void set_required_real_props_a(const ArgumentNameSet<REAL> &props) {
+    this->required_real_props_a = props;
+    this->index_on_device_object();
+  }
+
+  /**
+   * @brief Return all required real properties of the second particle
+   *
+   */
+  ArgumentNameSet<REAL> get_required_real_props_b() {
+    return this->required_real_props_b;
+  }
+
+  /**
+   * @brief Return all required real properties of the second particle as a
+   * vector of Syms
+   *
+   */
+  std::vector<Sym<REAL>> get_required_real_sym_vector_b() {
+    return this->required_real_props_b.to_sym_vector();
+  }
+
+  /**
+   * @brief Setter for required real properties of the second particle
+   *
+   * @param props ArgumentNameSet to use
+   */
+  void set_required_real_props_b(const ArgumentNameSet<REAL> &props) {
+    this->required_real_props_b = props;
+    this->index_on_device_object();
+  }
+
+  void set_rng_kernel(std::shared_ptr<RNG_TYPE> rng_kernel) {
+    this->rng_kernel = rng_kernel;
+  }
+
+  std::shared_ptr<RNG_TYPE> get_rng_kernel() { return this->rng_kernel; }
+
+  static constexpr size_t get_dim() { return dim; }
+
+  virtual ~PairReactionDataBase() = default;
+
+  /**
+   * @brief To be implemented by each derived class in order to handle required
+   * property indexing on the on-device object
+   */
+  virtual void index_on_device_object() {};
+
+  /**
+   * @brief Getter for the SYCL device-specific
+   * struct.
+   */
+  const ON_DEVICE_TYPE &get_on_device_obj() {
+
+    NESOASSERT(this->on_device_obj.has_value(),
+               "on_device_obj in PairReactionDataBase not initialised");
+    return this->on_device_obj.value();
+  }
+
+protected:
+  std::optional<ON_DEVICE_TYPE> on_device_obj;
+  ArgumentNameSet<INT> required_int_props_a;
+  ArgumentNameSet<REAL> required_real_props_a;
+  ArgumentNameSet<INT> required_int_props_b;
+  ArgumentNameSet<REAL> required_real_props_b;
+  std::shared_ptr<RNG_TYPE> rng_kernel;
+  std::map<int, std::string> properties_map;
+};
+
+/**
+ * @brief Base pair reaction data object to be used on SYCL devices.
+ *
+ * @tparam dim Used to set the size of the array that calc_data returns
+ * (Optional).
+ * @tparam RNG_TYPE Sets the type of RNG that is used for sampling (Optional).
+ * @tparam input_dim The dimension of the optional input array (for use in
+ * pipelines) (Optional, default 0)
+ * @tparam VAL_TYPE Return type of this objects calc_data routine (Optional,
+ * default REAL)
+ * @tparam IN_TYPE Input type of array required by this object (if input_dim >0)
+ */
+template <size_t dim = 1, typename RNG_TYPE = DEFAULT_RNG_KERNEL,
+          size_t input_dim = 0, typename VAL_TYPE = REAL,
+          typename IN_TYPE = REAL>
+struct PairReactionDataBaseOnDevice {
+  using RNG_KERNEL_TYPE = RNG_TYPE;
+  using VALUE_TYPE = VAL_TYPE;
+  using INPUT_TYPE = IN_TYPE;
+  static const size_t DIM = dim;
+  static const size_t INPUT_DIM = input_dim;
+
+  PairReactionDataBaseOnDevice() = default;
+
+  /**
+   * @brief Function to calculate the reaction data.
+   *
+   * @param index Read-only accessor to a pair loop index for a ParticlePairLoop
+   * inside which calc_data is called. Access using
+   * index.get_loop_linear_index().
+   * @param req_int_props_a Vector of symbols for integer-valued properties of
+   * the first particle that need to be used for the reaction data calculation.
+   * @param req_real_props_a Vector of symbols for real-valued properties of the
+   * first particle that need to be used for the reaction data calculation.
+   * @param req_int_props_b Vector of symbols for integer-valued properties of
+   * the second particle that need to be used for the reaction data calculation.
+   * @param req_real_props_b Vector of symbols for real-valued properties of the
+   * second particle that need to be used for the reaction data calculation.
+   * @param rng_kernel The random number generator kernel potentially used in
+   * the calculation
+   *
+   * @return A REAL-valued array of size dim containing the calculated reaction
+   * rate.
+   */
+  template <std::size_t D = INPUT_DIM,
+            std::enable_if_t<(D == 0) && D == INPUT_DIM, int> = 0>
+  std::array<VAL_TYPE, dim>
+  calc_data(const Access::PairLoopIndex::Read &index,
+            const Access::SymVector::Write<INT> &req_int_props_a,
+            const Access::SymVector::Read<REAL> &req_real_props_a,
+            const Access::SymVector::Write<INT> &req_int_props_b,
+            const Access::SymVector::Read<REAL> &req_real_props_b,
+            typename RNG_TYPE::KernelType &rng_kernel) const {
+    return std::array<REAL, dim>{0.0};
+  }
+
+  template <std::size_t D = INPUT_DIM,
+            std::enable_if_t<(D > 0) && D == INPUT_DIM, int> = 0>
+  std::array<VAL_TYPE, dim>
+  calc_data(const std::array<IN_TYPE, INPUT_DIM> &input,
+            const Access::PairLoopIndex::Read &index,
+            const Access::SymVector::Write<INT> &req_int_props_a,
+            const Access::SymVector::Read<REAL> &req_real_props_a,
+            const Access::SymVector::Write<INT> &req_int_props_b,
+            const Access::SymVector::Read<REAL> &req_real_props_b,
+            typename RNG_TYPE::KernelType &rng_kernel) const {
+    return std::array<REAL, dim>{0.0};
+  }
+  static constexpr size_t get_dim() { return dim; }
+};
+
+}; // namespace VANTAGE::Reactions
+#endif

--- a/src/reactions_lib/pair_reaction_data/cs_pair_reaction_data.hpp
+++ b/src/reactions_lib/pair_reaction_data/cs_pair_reaction_data.hpp
@@ -1,0 +1,153 @@
+#ifndef REACTIONS_CS_PAIR_REACTION_DATA_H
+#define REACTIONS_CS_PAIR_REACTION_DATA_H
+#include "../cross_sections/constant_rate_cs.hpp"
+#include "../pair_reaction_data.hpp"
+#include "../particle_properties_map.hpp"
+#include <iostream>
+#include <neso_particles.hpp>
+#include <vector>
+
+using namespace NESO::Particles;
+namespace VANTAGE::Reactions {
+
+/**
+ * @brief On device:Reaction class computing the sigma * v_r value for each
+ * particle pair
+ *
+ * @tparam vel_ndim The velocity space dimensionality
+ * @tparam CROSS_SECTION The typename corresponding to the cross-section class
+ * used
+ */
+template <size_t vel_ndim, typename CROSS_SECTION>
+struct CSPairDataOnDevice : public PairReactionDataBaseOnDevice<> {
+
+  CSPairDataOnDevice() = default;
+  /**
+   * @brief Constructor for CSPairDataOnDevice.
+   *
+   * @param cross_section Cross section object to be used in the rejection
+   * method sampling
+   */
+  CSPairDataOnDevice(CROSS_SECTION cross_section)
+      : cross_section(cross_section) {};
+
+  /**
+   * @brief Calculate sigma * v_r for a given pair of particles and given
+   * cross-section
+   *
+   * @param index Read-only accessor to a pair loop index for a ParticlePairLoop
+   * inside which calc_data is called. Access using
+   * index.get_loop_linear_index().
+   * @param req_int_props_a Vector of symbols for integer-valued properties of
+   * the first particle that need to be used for the reaction data calculation.
+   * @param req_real_props_a Vector of symbols for real-valued properties of the
+   * first particle that need to be used for the reaction data calculation.
+   * @param req_int_props_b Vector of symbols for integer-valued properties of
+   * the second particle that need to be used for the reaction data calculation.
+   * @param req_real_props_b Vector of symbols for real-valued properties of the
+   * second particle that need to be used for the reaction data calculation.
+   * @param rng_kernel The random number generator kernel potentially used in
+   * the calculation
+   *
+   * @return A REAL-valued array of size dim containing the calculated reaction
+   * rate.
+   */
+  std::array<REAL, 1>
+  calc_data(const Access::PairLoopIndex::Read &index,
+            const Access::SymVector::Write<INT> &req_int_props_a,
+            const Access::SymVector::Read<REAL> &req_real_props_a,
+            const Access::SymVector::Write<INT> &req_int_props_b,
+            const Access::SymVector::Read<REAL> &req_real_props_b,
+            typename PairReactionDataBaseOnDevice::RNG_KERNEL_TYPE::KernelType
+                &rng_kernel) const {
+
+    REAL rel_speed = 0;
+    REAL rel_vel;
+    for (int i = 0; i < vel_ndim; i++) {
+      rel_vel = req_real_props_a.at(this->velocity_ind_a, i) -
+                req_real_props_b.at(this->velocity_ind_b, i);
+      rel_speed += rel_vel * rel_vel;
+    }
+    rel_speed = Kernel::sqrt(rel_speed);
+
+    return std::array<REAL, 1>{this->cross_section.get_value_at(rel_speed) *
+                               rel_speed};
+  }
+
+  /**
+   * @brief Return the maximum rate value from the contained cross section up to
+   * some maximum relative velocity
+   *
+   * @param max_rel_vel
+   * @return REAL-valued maximum rate
+   */
+  REAL get_cs_max_rate_val(REAL max_rel_vel) {
+    return this->cross_section.get_max_rate_val(max_rel_vel);
+  }
+
+public:
+  int velocity_ind_a, velocity_ind_b;
+  CROSS_SECTION cross_section;
+};
+
+/**
+ * @brief Reaction class computing the sigma * v_r value for each particle pair
+ *
+ * @tparam vel_ndim The velocity space dimensionality
+ * @tparam CROSS_SECTION The typename corresponding to the cross-section class
+ * used
+ */
+template <size_t vel_ndim, typename CROSS_SECTION = ConstantRateCrossSection>
+struct CSPairData
+    : public PairReactionDataBase<CSPairDataOnDevice<vel_ndim, CROSS_SECTION>> {
+
+  constexpr static auto props = default_properties;
+
+  constexpr static auto required_simple_real_props =
+      std::array<int, 1>{props.velocity};
+
+  /**
+   * @brief Constructor for CSPairData.
+   *
+   * @param cross_section Cross section object to be used in the calculation
+   * @param properties_map (Optional) A std::map<int, std::string> object to be
+   * used when remapping property names.
+   */
+  CSPairData(CROSS_SECTION cross_section,
+             std::map<int, std::string> properties_map = get_default_map())
+      : PairReactionDataBase<CSPairDataOnDevice<vel_ndim, CROSS_SECTION>>(
+            Properties<REAL>(required_simple_real_props), properties_map) {
+    this->on_device_obj =
+        CSPairDataOnDevice<vel_ndim, CROSS_SECTION>(cross_section);
+
+    static_assert(std::is_base_of_v<AbstractCrossSection, CROSS_SECTION>,
+                  "Template parameter CROSS_SECTION is not derived from "
+                  "AbstractCrossSection...");
+
+    this->index_on_device_object();
+  }
+
+  /**
+   * \overload
+   * @brief Constructor which sets default values for the
+   * cross_section and properties_map.
+   *
+   */
+  CSPairData() : CSPairData(ConstantRateCrossSection(0.0)) {}
+
+  /**
+   * @brief Index the particle velocity temperature
+   */
+  void index_on_device_object() {
+
+    this->on_device_obj->velocity_ind_a =
+        this->required_real_props_a.find_index(
+            this->properties_map.at(props.velocity));
+
+    this->on_device_obj->velocity_ind_b =
+        this->required_real_props_b.find_index(
+            this->properties_map.at(props.velocity));
+  };
+};
+}; // namespace VANTAGE::Reactions
+#endif

--- a/src/reactions_lib/pair_reaction_data/cs_pair_reaction_data.hpp
+++ b/src/reactions_lib/pair_reaction_data/cs_pair_reaction_data.hpp
@@ -15,10 +15,10 @@ namespace VANTAGE::Reactions {
  * particle pair
  *
  * @tparam vel_ndim The velocity space dimensionality
- * @tparam CROSS_SECTION The typename corresponding to the cross-section class
+ * @tparam CROSS_SECTION_T The typename corresponding to the cross-section class
  * used
  */
-template <size_t vel_ndim, typename CROSS_SECTION>
+template <size_t vel_ndim, typename CROSS_SECTION_T>
 struct CSPairDataOnDevice : public PairReactionDataBaseOnDevice<> {
 
   CSPairDataOnDevice() = default;
@@ -28,7 +28,7 @@ struct CSPairDataOnDevice : public PairReactionDataBaseOnDevice<> {
    * @param cross_section Cross section object to be used in the rejection
    * method sampling
    */
-  CSPairDataOnDevice(CROSS_SECTION cross_section)
+  CSPairDataOnDevice(CROSS_SECTION_T cross_section)
       : cross_section(cross_section) {};
 
   std::array<REAL, 1>
@@ -62,19 +62,19 @@ struct CSPairDataOnDevice : public PairReactionDataBaseOnDevice<> {
 
 public:
   int velocity_ind_a, velocity_ind_b;
-  CROSS_SECTION cross_section;
+  CROSS_SECTION_T cross_section;
 };
 
 /**
  * @brief Reaction class computing the sigma * v_r value for each particle pair
  *
  * @tparam vel_ndim The velocity space dimensionality
- * @tparam CROSS_SECTION The typename corresponding to the cross-section class
+ * @tparam CROSS_SECTION_T The typename corresponding to the cross-section class
  * used
  */
-template <size_t vel_ndim, typename CROSS_SECTION = ConstantRateCrossSection>
-struct CSPairData
-    : public PairReactionDataBase<CSPairDataOnDevice<vel_ndim, CROSS_SECTION>> {
+template <size_t vel_ndim, typename CROSS_SECTION_T = ConstantRateCrossSection>
+struct CSPairData : public PairReactionDataBase<
+                        CSPairDataOnDevice<vel_ndim, CROSS_SECTION_T>> {
 
   constexpr static auto props = default_properties;
 
@@ -88,15 +88,15 @@ struct CSPairData
    * @param properties_map (Optional) A std::map<int, std::string> object to be
    * used when remapping property names.
    */
-  CSPairData(CROSS_SECTION cross_section,
+  CSPairData(CROSS_SECTION_T cross_section,
              std::map<int, std::string> properties_map = get_default_map())
-      : PairReactionDataBase<CSPairDataOnDevice<vel_ndim, CROSS_SECTION>>(
+      : PairReactionDataBase<CSPairDataOnDevice<vel_ndim, CROSS_SECTION_T>>(
             Properties<REAL>(required_simple_real_props), properties_map) {
     this->on_device_obj =
-        CSPairDataOnDevice<vel_ndim, CROSS_SECTION>(cross_section);
+        CSPairDataOnDevice<vel_ndim, CROSS_SECTION_T>(cross_section);
 
-    static_assert(std::is_base_of_v<AbstractCrossSection, CROSS_SECTION>,
-                  "Template parameter CROSS_SECTION is not derived from "
+    static_assert(std::is_base_of_v<AbstractCrossSection, CROSS_SECTION_T>,
+                  "Template parameter CROSS_SECTION_T is not derived from "
                   "AbstractCrossSection...");
 
     this->index_on_device_object();

--- a/src/reactions_lib/pair_reaction_data/cs_pair_reaction_data.hpp
+++ b/src/reactions_lib/pair_reaction_data/cs_pair_reaction_data.hpp
@@ -31,41 +31,16 @@ struct CSPairDataOnDevice : public PairReactionDataBaseOnDevice<> {
   CSPairDataOnDevice(CROSS_SECTION cross_section)
       : cross_section(cross_section) {};
 
-  /**
-   * @brief Calculate sigma * v_r for a given pair of particles and given
-   * cross-section
-   *
-   * @param index Read-only accessor to a pair loop index for a ParticlePairLoop
-   * inside which calc_data is called. Access using
-   * index.get_loop_linear_index().
-   * @param req_int_props_a Vector of symbols for integer-valued properties of
-   * the first particle that need to be used for the reaction data calculation.
-   * @param req_real_props_a Vector of symbols for real-valued properties of the
-   * first particle that need to be used for the reaction data calculation.
-   * @param req_int_props_b Vector of symbols for integer-valued properties of
-   * the second particle that need to be used for the reaction data calculation.
-   * @param req_real_props_b Vector of symbols for real-valued properties of the
-   * second particle that need to be used for the reaction data calculation.
-   * @param rng_kernel The random number generator kernel potentially used in
-   * the calculation
-   *
-   * @return A REAL-valued array of size dim containing the calculated reaction
-   * rate.
-   */
   std::array<REAL, 1>
-  calc_data(const Access::PairLoopIndex::Read &index,
-            const Access::SymVector::Write<INT> &req_int_props_a,
-            const Access::SymVector::Read<REAL> &req_real_props_a,
-            const Access::SymVector::Write<INT> &req_int_props_b,
-            const Access::SymVector::Read<REAL> &req_real_props_b,
+  calc_data(const PairReactionDataAccessors &accessor_pack,
             typename PairReactionDataBaseOnDevice::RNG_KERNEL_TYPE::KernelType
                 &rng_kernel) const {
 
     REAL rel_speed = 0;
     REAL rel_vel;
     for (int i = 0; i < vel_ndim; i++) {
-      rel_vel = req_real_props_a.at(this->velocity_ind_a, i) -
-                req_real_props_b.at(this->velocity_ind_b, i);
+      rel_vel = accessor_pack.req_real_props_a.at(this->velocity_ind_a, i) -
+                accessor_pack.req_real_props_b.at(this->velocity_ind_b, i);
       rel_speed += rel_vel * rel_vel;
     }
     rel_speed = Kernel::sqrt(rel_speed);
@@ -140,12 +115,13 @@ struct CSPairData
    */
   void index_on_device_object() {
 
+    auto arg_pack = this->get_arg_pack();
     this->on_device_obj->velocity_ind_a =
-        this->required_real_props_a.find_index(
+        arg_pack.required_real_props_a.find_index(
             this->properties_map.at(props.velocity));
 
     this->on_device_obj->velocity_ind_b =
-        this->required_real_props_b.find_index(
+        arg_pack.required_real_props_b.find_index(
             this->properties_map.at(props.velocity));
   };
 };

--- a/src/reactions_lib/pair_reaction_kernels.hpp
+++ b/src/reactions_lib/pair_reaction_kernels.hpp
@@ -1,0 +1,513 @@
+#ifndef REACTIONS_PAIR_REACTION_KERNELS_H
+#define REACTIONS_PAIR_REACTION_KERNELS_H
+#include "particle_properties_map.hpp"
+#include "reaction_kernel_pre_reqs.hpp"
+#include <neso_particles.hpp>
+
+using namespace NESO::Particles;
+namespace VANTAGE::Reactions {
+
+/**
+ * @brief Base pair reaction kernels object.
+ */
+struct PairReactionKernelsBase {
+
+  /**
+   * @brief Constructor for PairReactionKernelsBase.
+   *
+   * @param req_int_props_a Vector of symbols for integer-valued properties of
+   * the first particle that need to be used for the reaction kernel.
+   * @param req_real_props_a Vector of symbols for real-valued properties of the
+   * first particle that need to be used for the reaction kernel.
+   * @param req_int_props_b Vector of symbols for integer-valued properties of
+   * the second particle that need to be used for the reaction kernel.
+   * @param req_real_props_b Vector of symbols for real-valued properties of the
+   * second particle that need to be used for the reaction kernel.
+   * kernel.
+   * @param pre_req_ndims (Optional) Integer defining the number of dimensions
+   * required by a reaction kernel (this in turn matches the number of
+   * ReactionData-derived objects that must be passed to the constructor of a
+   * PairDataCalculator object when this kernel and the PairDataCalculator
+   * object are passed to corresponding reaction object).
+   * @param properties_map (Optional) A std::map<int, std::string> object to be
+   * used when remapping property names (in get_required_real_props(...) and
+   * get_required_int_props(...)).
+   */
+  PairReactionKernelsBase(
+      Properties<INT> req_int_props_a, Properties<REAL> req_real_props_a,
+      Properties<INT> req_int_props_b, Properties<REAL> req_real_props_b,
+      INT pre_req_ndims = 0,
+      std::map<int, std::string> properties_map = get_default_map())
+      : required_int_props_a(req_int_props_a),
+        required_real_props_a(req_real_props_a),
+        required_int_props_b(req_int_props_b),
+        required_real_props_b(req_real_props_b), pre_req_ndims(pre_req_ndims) {
+    NESOWARN(
+        map_subset_check(properties_map),
+        "The provided properties_map does not include all the keys from the \
+        default_map (and therefore is not an extension of that map). There \
+        may be inconsitencies with indexing of properties.");
+
+    this->properties_map = properties_map;
+  }
+
+  /**
+   * \overload
+   * @brief Constructor for PairReactionKernelsBase that by default sets no
+   * required props.
+   *
+   * @param properties_map (Optional) A std::map<int, std::string> object to be
+   * used when remapping property names (in get_required_real_props(...) and
+   * get_required_int_props(...)).
+   */
+  PairReactionKernelsBase(
+      std::map<int, std::string> properties_map = get_default_map())
+      : PairReactionKernelsBase(Properties<INT>(), Properties<REAL>(),
+                                Properties<INT>(), Properties<REAL>(), 0,
+                                properties_map) {}
+
+  /**
+   * \overload
+   * @brief Constructor for PairReactionKernelsBase that by default only sets
+   * required_int_props and sets them the same for both particles.
+   *
+   * @param required_int_props Properties<INT> object containing information
+   * regarding the required INT-based properties for the reaction kernel.
+   * @param pre_req_ndims (Optional) Integer defining the number of dimensions
+   * required by a reaction kernel (this in turn matches the number of
+   * ReactionData-derived objects that must be passed to the constructor of a
+   * PairDataCalculator object when this kernel and the PairDataCalculator
+   * object are passed to corresponding reaction object).
+   * @param properties_map (Optional) A std::map<int, std::string> object to be
+   * used when remapping property names (in get_required_real_props(...) and
+   * get_required_int_props(...)).
+   */
+  PairReactionKernelsBase(
+      Properties<INT> required_int_props, INT pre_req_ndims = 0,
+      std::map<int, std::string> properties_map = get_default_map())
+      : PairReactionKernelsBase(required_int_props, Properties<REAL>(),
+                                required_int_props, Properties<REAL>(),
+                                pre_req_ndims, properties_map) {}
+
+  /**
+   * \overload
+   * @brief Constructor for PairReactionKernelsBase that by default only sets
+   * required_real_props and sets them the same for both particles.
+   *
+   * @param required_real_props Properties<REAL> object containing information
+   * regarding the required REAL-based properties for the reaction kernel.
+   * @param pre_req_ndims (Optional) Integer defining the number of dimensions
+   * required by a reaction kernel (this in turn matches the number of
+   * ReactionData-derived objects that must be passed to the constructor of a
+   * PairDataCalculator object when this kernel and the PairDataCalculator
+   * object are passed to corresponding reaction object).
+   * @param properties_map (Optional) A std::map<int, std::string> object to be
+   * used when remapping property names (in get_required_real_props(...) and
+   * get_required_int_props(...)).
+   */
+  PairReactionKernelsBase(
+      Properties<REAL> required_real_props, INT pre_req_ndims = 0,
+      std::map<int, std::string> properties_map = get_default_map())
+      : PairReactionKernelsBase(Properties<INT>(), required_real_props,
+                                Properties<INT>(), required_real_props,
+                                pre_req_ndims, properties_map) {}
+
+  /**
+   * \overload
+   * @brief Constructor for PairReactionKernelsBase that sets the same required
+   * properties for both particles.
+   *
+   * @param required_int_props Properties<INT> object containing information
+   * regarding the required INT-based properties for the reaction kernel.
+   * @param required_real_props Properties<REAL> object containing information
+   * regarding the required REAL-based properties for the reaction kernel.
+   * @param pre_req_ndims (Optional) Integer defining the number of dimensions
+   * required by a reaction kernel (this in turn matches the number of
+   * ReactionData-derived objects that must be passed to the constructor of a
+   * PairDataCalculator object when this kernel and the PairDataCalculator
+   * object are passed to corresponding reaction object).
+   * @param properties_map (Optional) A std::map<int, std::string> object to be
+   * used when remapping property names (in get_required_real_props(...) and
+   * get_required_int_props(...)).
+   */
+  PairReactionKernelsBase(
+      Properties<INT> required_int_props, Properties<REAL> required_real_props,
+      INT pre_req_ndims = 0,
+      std::map<int, std::string> properties_map = get_default_map())
+      : PairReactionKernelsBase(required_int_props, required_real_props,
+                                required_int_props, required_real_props,
+                                pre_req_ndims, properties_map) {}
+
+  virtual ~PairReactionKernelsBase() = default;
+
+  /**
+   * @brief Return all required integer property names for the first particle
+   *
+   */
+  std::vector<std::string> get_required_int_props_a() {
+    return this->required_int_props_a.get_prop_names(this->properties_map);
+  }
+
+  /**
+   * @brief Return all required integer property names for the second particle
+   *
+   */
+  std::vector<std::string> get_required_int_props_b() {
+    return this->required_int_props_b.get_prop_names(this->properties_map);
+  }
+  /**
+   * @brief Return all required real property names for the first particle
+   *
+   */
+  std::vector<std::string> get_required_real_props_a() {
+    return this->required_real_props_a.get_prop_names(this->properties_map);
+  }
+
+  /**
+   * @brief Return all required real property names for the second particle
+   *
+   */
+  std::vector<std::string> get_required_real_props_b() {
+    return this->required_real_props_b.get_prop_names(this->properties_map);
+  }
+
+  const Properties<INT> &get_required_descendant_int_props_a() {
+    return this->required_descendant_int_props_a;
+  }
+
+  const Properties<REAL> &get_required_descendant_real_props_a() {
+    return this->required_descendant_real_props_a;
+  }
+
+  const Properties<INT> &get_required_descendant_int_props_b() {
+    return this->required_descendant_int_props_b;
+  }
+
+  const Properties<REAL> &get_required_descendant_real_props_b() {
+    return this->required_descendant_real_props_b;
+  }
+  std::shared_ptr<ProductMatrixSpec> get_descendant_matrix_spec_a() {
+    return this->descendant_matrix_spec_a;
+  }
+
+  std::shared_ptr<ProductMatrixSpec> get_descendant_matrix_spec_b() {
+    return this->descendant_matrix_spec_b;
+  }
+  const INT &get_pre_ndims() const { return this->pre_req_ndims; }
+
+protected:
+  void set_required_descendant_int_props_a(
+      const Properties<INT> &required_descendant_int_props) {
+    this->required_descendant_int_props_a = required_descendant_int_props;
+  }
+
+  void set_required_descendant_real_props_a(
+      const Properties<REAL> &required_descendant_real_props) {
+    this->required_descendant_real_props_a = required_descendant_real_props;
+  }
+
+  void set_required_descendant_int_props_b(
+      const Properties<INT> &required_descendant_int_props) {
+    this->required_descendant_int_props_b = required_descendant_int_props;
+  }
+
+  void set_required_descendant_real_props_b(
+      const Properties<REAL> &required_descendant_real_props) {
+    this->required_descendant_real_props_b = required_descendant_real_props;
+  }
+
+  template <int ndim_velocity = 2, int num_products_per_parent = 0>
+  void set_descendant_matrix_spec_a() {
+    if constexpr (num_products_per_parent < 1) {
+      return;
+    } else {
+      NESOWARN(
+          ((this->required_descendant_int_props_a.get_props().size() == 0) &&
+           (this->required_descendant_real_props_a.get_props().size() == 0)),
+          "The number of products per parent is >= 1 but no required "
+          "descendant properties are set. This will result in an empty "
+          "descendant_matrix_spec.")
+
+      auto descendant_particles_spec = ParticleSpec();
+
+      for (auto prop : this->required_descendant_int_props_a.get_props()) {
+        auto descendant_prop =
+            ParticleProp<INT>(Sym<INT>(this->properties_map.at(prop)), 1);
+        descendant_particles_spec.push(descendant_prop);
+      }
+
+      for (auto prop : this->required_descendant_real_props_a.get_props()) {
+        if (prop == default_properties.velocity) {
+          auto descendant_prop = ParticleProp<REAL>(
+              Sym<REAL>(this->properties_map.at(prop)), ndim_velocity);
+          descendant_particles_spec.push(descendant_prop);
+        } else {
+          auto descendant_prop =
+              ParticleProp<REAL>(Sym<REAL>(this->properties_map.at(prop)), 1);
+          descendant_particles_spec.push(descendant_prop);
+        }
+      }
+
+      this->descendant_matrix_spec_a =
+          product_matrix_spec(descendant_particles_spec);
+    }
+  }
+
+  template <int ndim_velocity = 2, int num_products_per_parent = 0>
+  void set_descendant_matrix_spec_b() {
+    if constexpr (num_products_per_parent < 1) {
+      return;
+    } else {
+      NESOWARN(
+          ((this->required_descendant_int_props_b.get_props().size() == 0) &&
+           (this->required_descendant_real_props_b.get_props().size() == 0)),
+          "The number of products per parent is >= 1 but no required "
+          "descendant properties are set. This will result in an empty "
+          "descendant_matrix_spec.")
+
+      auto descendant_particles_spec = ParticleSpec();
+
+      for (auto prop : this->required_descendant_int_props_b.get_props()) {
+        auto descendant_prop =
+            ParticleProp<INT>(Sym<INT>(this->properties_map.at(prop)), 1);
+        descendant_particles_spec.push(descendant_prop);
+      }
+
+      for (auto prop : this->required_descendant_real_props_b.get_props()) {
+        if (prop == default_properties.velocity) {
+          auto descendant_prop = ParticleProp<REAL>(
+              Sym<REAL>(this->properties_map.at(prop)), ndim_velocity);
+          descendant_particles_spec.push(descendant_prop);
+        } else {
+          auto descendant_prop =
+              ParticleProp<REAL>(Sym<REAL>(this->properties_map.at(prop)), 1);
+          descendant_particles_spec.push(descendant_prop);
+        }
+      }
+
+      this->descendant_matrix_spec_b =
+          product_matrix_spec(descendant_particles_spec);
+    }
+  }
+  Properties<INT> required_int_props_a;
+  Properties<REAL> required_real_props_a;
+  Properties<INT> required_int_props_b;
+  Properties<REAL> required_real_props_b;
+
+  Properties<INT> required_descendant_int_props_a;
+  Properties<REAL> required_descendant_real_props_a;
+
+  Properties<INT> required_descendant_int_props_b;
+  Properties<REAL> required_descendant_real_props_b;
+
+  std::shared_ptr<ProductMatrixSpec> descendant_matrix_spec_a =
+      std::make_shared<ProductMatrixSpec>();
+
+  std::shared_ptr<ProductMatrixSpec> descendant_matrix_spec_b =
+      std::make_shared<ProductMatrixSpec>();
+
+  INT pre_req_ndims;
+
+  std::map<int, std::string> properties_map;
+};
+
+/**
+ * @brief Base pair reaction kernels object to be used on SYCL devices.
+ *
+ * @tparam num_products_per_parent The number of products produced per parent
+ * by a reaction.
+ */
+template <int num_products_per_parent> struct PairReactionKernelsBaseOnDevice {
+  PairReactionKernelsBaseOnDevice() = default;
+
+  /**
+   * @brief Parent setting kernel determining which product inherits from which
+   * parent. Should call .set_parent on the corresponding descendant products.
+   *
+   * @param index_a Read-only accessor to a loop index for the first particle
+   * @param index_b Read-only accessor to a loop index for the second particle
+   * @param descendant_products_a Write accessor to descendant products of the
+   * first particle
+   * @param descendant_products_b Write accessor to descendant products of the
+   * second particle
+   * @param out_states Array defining the IDs of descendant particles
+   */
+  void parent_kernel(
+      Access::LoopIndex::Read &index_a, Access::LoopIndex::Read &index_b,
+      Access::DescendantProducts::Write &descendant_products_a,
+      Access::DescendantProducts::Write &descendant_products_b,
+      const std::array<int, num_products_per_parent> &out_states) const {
+    return;
+  }
+
+  /**
+   * @brief Base scattering kernel for calculating and applying
+   * reaction-derived velocity modifications of the particles.
+   *
+   * @param modified_weight The weight modification needed for calculating
+   * the changes to the background fields.
+   * @param index_a Read-only accessor to a loop index for the first particle
+   * @param index_b Read-only accessor to a loop index for the second particle
+   * @param pair_index Read-only accessor to a pair loop index for a
+   * ParticlePairLoop inside which apply is called. Access using
+   * pair_index.get_loop_linear_index().
+   * @param descendant_products_a Write accessor to descendant products of the
+   * first particle
+   * @param descendant_products_b Write accessor to descendant products of the
+   * second particle
+   * @param req_int_props_a Vector of symbols for integer-valued properties of
+   * the first particle that need to be used for the reaction kernel.
+   * @param req_real_props_a Vector of symbols for real-valued properties of the
+   * first particle that need to be used for the reaction kernel.
+   * @param req_int_props_b Vector of symbols for integer-valued properties of
+   * the second particle that need to be used for the reaction kernel.
+   * @param req_real_props_b Vector of symbols for real-valued properties of the
+   * second particle that need to be used for the reaction kernel.
+   * @param out_states Array defining the IDs of descendant particles
+   * @param pre_req_data Real-valued local array containing pre-requisite
+   * data relating to a derived reaction.
+   * @param dt The current time step size.
+   */
+  void scattering_kernel(
+      REAL &modified_weight, Access::LoopIndex::Read &index_a,
+      Access::LoopIndex::Read &index_b, Access::PairLoopIndex::Read &pair_index,
+      Access::DescendantProducts::Write &descendant_products_a,
+      Access::DescendantProducts::Write &descendant_products_b,
+      Access::SymVector::Write<INT> &req_int_props_a,
+      Access::SymVector::Write<REAL> &req_real_props_a,
+      Access::SymVector::Write<INT> &req_int_props_b,
+      Access::SymVector::Write<REAL> &req_real_props_b,
+      const std::array<int, num_products_per_parent> &out_states,
+      Access::NDLocalArray::Read<REAL, 2> &pre_req_data, double dt) const {
+    return;
+  }
+  /**
+   * @brief Base feedback kernel for calculating and applying
+   * background field modifications from the reaction.
+   *
+   * @param modified_weight The weight modification needed for calculating
+   * the changes to the background fields.
+   * @param index_a Read-only accessor to a loop index for the first particle
+   * @param index_b Read-only accessor to a loop index for the second particle
+   * @param pair_index Read-only accessor to a pair loop index for a
+   * ParticlePairLoop inside which apply is called. Access using
+   * pair_index.get_loop_linear_index().
+   * @param descendant_products_a Write accessor to descendant products of the
+   * first particle
+   * @param descendant_products_b Write accessor to descendant products of the
+   * second particle
+   * @param req_int_props_a Vector of symbols for integer-valued properties of
+   * the first particle that need to be used for the reaction kernel.
+   * @param req_real_props_a Vector of symbols for real-valued properties of the
+   * first particle that need to be used for the reaction kernel.
+   * @param req_int_props_b Vector of symbols for integer-valued properties of
+   * the second particle that need to be used for the reaction kernel.
+   * @param req_real_props_b Vector of symbols for real-valued properties of the
+   * second particle that need to be used for the reaction kernel.
+   * @param out_states Array defining the IDs of descendant particles
+   * @param pre_req_data Real-valued local array containing pre-requisite
+   * data relating to a derived reaction.
+   * @param dt The current time step size.
+   */
+  void feedback_kernel(
+      REAL &modified_weight, Access::LoopIndex::Read &index_a,
+      Access::LoopIndex::Read &index_b, Access::PairLoopIndex::Read &pair_index,
+      Access::DescendantProducts::Write &descendant_products_a,
+      Access::DescendantProducts::Write &descendant_products_b,
+      Access::SymVector::Write<INT> &req_int_props_a,
+      Access::SymVector::Write<REAL> &req_real_props_a,
+      Access::SymVector::Write<INT> &req_int_props_b,
+      Access::SymVector::Write<REAL> &req_real_props_b,
+      const std::array<int, num_products_per_parent> &out_states,
+      Access::NDLocalArray::Read<REAL, 2> &pre_req_data, double dt) const {
+    return;
+  }
+
+  /**
+   * @brief Base transformation kernel for calculating and applying
+   * reaction-derived ID modifications of the particles.
+   *
+   * @param modified_weight The weight modification needed for calculating
+   * the changes to the background fields.
+   * @param index_a Read-only accessor to a loop index for the first particle
+   * @param index_b Read-only accessor to a loop index for the second particle
+   * @param pair_index Read-only accessor to a pair loop index for a
+   * ParticlePairLoop inside which apply is called. Access using
+   * pair_index.get_loop_linear_index().
+   * @param descendant_products_a Write accessor to descendant products of the
+   * first particle
+   * @param descendant_products_b Write accessor to descendant products of the
+   * second particle
+   * @param req_int_props_a Vector of symbols for integer-valued properties of
+   * the first particle that need to be used for the reaction kernel.
+   * @param req_real_props_a Vector of symbols for real-valued properties of the
+   * first particle that need to be used for the reaction kernel.
+   * @param req_int_props_b Vector of symbols for integer-valued properties of
+   * the second particle that need to be used for the reaction kernel.
+   * @param req_real_props_b Vector of symbols for real-valued properties of the
+   * second particle that need to be used for the reaction kernel.
+   * @param out_states Array defining the IDs of descendant particles
+   * @param pre_req_data Real-valued local array containing pre-requisite
+   * data relating to a derived reaction.
+   * @param dt The current time step size.
+   *
+   */
+  void transformation_kernel(
+      REAL &modified_weight, Access::LoopIndex::Read &index_a,
+      Access::LoopIndex::Read &index_b, Access::PairLoopIndex::Read &pair_index,
+      Access::DescendantProducts::Write &descendant_products_a,
+      Access::DescendantProducts::Write &descendant_products_b,
+      Access::SymVector::Write<INT> &req_int_props_a,
+      Access::SymVector::Write<REAL> &req_real_props_a,
+      Access::SymVector::Write<INT> &req_int_props_b,
+      Access::SymVector::Write<REAL> &req_real_props_b,
+      const std::array<int, num_products_per_parent> &out_states,
+      Access::NDLocalArray::Read<REAL, 2> &pre_req_data, double dt) const {
+    return;
+  }
+  /**
+   * @brief Base weight kernel for calculating and applying
+   * reaction-derived weight modifications of the particles.
+   *
+   * @param modified_weight The weight modification needed for calculating
+   * the changes to the background fields.
+   * @param index_a Read-only accessor to a loop index for the first particle
+   * @param index_b Read-only accessor to a loop index for the second particle
+   * @param pair_index Read-only accessor to a pair loop index for a
+   * ParticlePairLoop inside which apply is called. Access using
+   * pair_index.get_loop_linear_index().
+   * @param descendant_products_a Write accessor to descendant products of the
+   * first particle
+   * @param descendant_products_b Write accessor to descendant products of the
+   * second particle
+   * @param req_int_props_a Vector of symbols for integer-valued properties of
+   * the first particle that need to be used for the reaction kernel.
+   * @param req_real_props_a Vector of symbols for real-valued properties of the
+   * first particle that need to be used for the reaction kernel.
+   * @param req_int_props_b Vector of symbols for integer-valued properties of
+   * the second particle that need to be used for the reaction kernel.
+   * @param req_real_props_b Vector of symbols for real-valued properties of the
+   * second particle that need to be used for the reaction kernel.
+   * @param out_states Array defining the IDs of descendant particles
+   * @param pre_req_data Real-valued local array containing pre-requisite
+   * data relating to a derived reaction.
+   * @param dt The current time step size.
+   *
+   */
+  void weight_kernel(REAL &modified_weight, Access::LoopIndex::Read &index_a,
+                     Access::LoopIndex::Read &index_b,
+                     Access::PairLoopIndex::Read &pair_index,
+                     Access::DescendantProducts::Write &descendant_products_a,
+                     Access::DescendantProducts::Write &descendant_products_b,
+                     Access::SymVector::Write<INT> &req_int_props_a,
+                     Access::SymVector::Write<REAL> &req_real_props_a,
+                     Access::SymVector::Write<INT> &req_int_props_b,
+                     Access::SymVector::Write<REAL> &req_real_props_b,
+                     const std::array<int, num_products_per_parent> &out_states,
+                     Access::NDLocalArray::Read<REAL, 2> &pre_req_data,
+                     double dt) const {
+    return;
+  }
+};
+}; // namespace VANTAGE::Reactions
+#endif

--- a/src/reactions_lib/reaction_data.hpp
+++ b/src/reactions_lib/reaction_data.hpp
@@ -46,6 +46,20 @@ struct AbstractCrossSection {
   };
 
   /**
+   * @brief Get the greedy maximum value of sigma*v_r where sigma is this
+   * cross-section evaluated at v_r and v_r is the relative speed of the
+   * projectile and target. This should (in most cases) be implemented to return
+   * values less than or equal to the one with get_max_rate_val()
+   *
+   * @param relative_vel Magnitude of relative velocity of the projectile and
+   * target
+   * @return REAL-valued maximum rate
+   */
+  REAL get_max_rate_val(REAL relative_vel) const {
+    // TODO: check if this still causes issues (see workarounds below)
+    return this->get_max_rate_val();
+  };
+  /**
    * @brief Accept-reject function for when this cross-section is used in
    * rejection methods. Accepts if the uniform random number on (0,1) is less
    * than the ratio of sigma*v evaluated at a given relative speed to the

--- a/src/reactions_lib/reaction_data_abstract.hpp
+++ b/src/reactions_lib/reaction_data_abstract.hpp
@@ -82,13 +82,13 @@ constexpr bool check_abstract_calc_data_return_type() {
   }
 }
 
-template <typename ON_DEVICE_TYPE, typename ARGUMENT_PACK, size_t dim = 1,
-          typename RNG_TYPE = DEFAULT_RNG_KERNEL, size_t input_dim = 0>
+template <typename ON_DEVICE_T, typename ARGUMENT_PACK_T, size_t dim = 1,
+          typename RNG_KERNEL_T = DEFAULT_RNG_KERNEL, size_t input_dim = 0>
 struct AbstractReactionData {
 
-  using RNG_KERNEL_TYPE = RNG_TYPE;
-  using ARG_PACK = ARGUMENT_PACK;
-  using ON_DEVICE_OBJ_TYPE = ON_DEVICE_TYPE;
+  using RNG_KERNEL_TYPE = RNG_KERNEL_T;
+  using ARGUMENT_PACK_TYPE = ARGUMENT_PACK_T;
+  using ON_DEVICE_OBJ_TYPE = ON_DEVICE_T;
   static const size_t DIM = dim;
   static const size_t INPUT_DIM = input_dim;
 
@@ -97,47 +97,47 @@ struct AbstractReactionData {
    * parameter signature and return type expected by this host base class.
    */
   static constexpr bool validate_on_device_type() {
-    if constexpr (ON_DEVICE_TYPE::INPUT_DIM > 0) {
-      using input_t = const std::array<typename ON_DEVICE_TYPE::INPUT_TYPE,
-                                       ON_DEVICE_TYPE::INPUT_DIM> &;
+    if constexpr (ON_DEVICE_T::INPUT_DIM > 0) {
+      using input_t = const std::array<typename ON_DEVICE_T::INPUT_TYPE,
+                                       ON_DEVICE_T::INPUT_DIM> &;
 
       static_assert(is_abstract_calc_data_callable_v<
-                        ON_DEVICE_TYPE, input_t,
-                        const typename ON_DEVICE_TYPE::ACC_PACK &,
-                        typename RNG_TYPE::KernelType &>,
-                    "ON_DEVICE_TYPE::calc_data parameter signature mismatch");
+                        ON_DEVICE_T, input_t,
+                        const typename ON_DEVICE_T::ACCESSOR_PACK_TYPE &,
+                        typename RNG_KERNEL_T::KernelType &>,
+                    "ON_DEVICE_T::calc_data parameter signature mismatch");
 
-      static_assert(check_abstract_calc_data_return_type<
-                        ON_DEVICE_TYPE,
-                        std::array<typename ON_DEVICE_TYPE::VALUE_TYPE,
-                                   ON_DEVICE_TYPE::DIM>,
-                        input_t, const typename ON_DEVICE_TYPE::ACC_PACK &,
-                        typename RNG_TYPE::KernelType &>(),
-                    "ON_DEVICE_TYPE::calc_data return type mismatch");
+      static_assert(
+          check_abstract_calc_data_return_type<
+              ON_DEVICE_T,
+              std::array<typename ON_DEVICE_T::VALUE_TYPE, ON_DEVICE_T::DIM>,
+              input_t, const typename ON_DEVICE_T::ACCESSOR_PACK_TYPE &,
+              typename RNG_KERNEL_T::KernelType &>(),
+          "ON_DEVICE_T::calc_data return type mismatch");
     }
     return true;
   }
 
   AbstractReactionData(
-      ARGUMENT_PACK argument_pack,
+      ARGUMENT_PACK_T argument_pack,
       std::map<int, std::string> properties_map = get_default_map())
       : argument_pack(argument_pack), properties_map(properties_map) {
 
     static_assert(validate_on_device_type());
-    this->rng_kernel = std::make_shared<RNG_TYPE>();
+    this->rng_kernel = std::make_shared<RNG_KERNEL_T>();
   }
 
-  ARGUMENT_PACK get_arg_pack() { return this->argument_pack; }
-  void set_arg_pack(const ARGUMENT_PACK &argument_pack) {
+  ARGUMENT_PACK_T get_arg_pack() { return this->argument_pack; }
+  void set_arg_pack(const ARGUMENT_PACK_T &argument_pack) {
     this->argument_pack = argument_pack;
     this->index_on_device_object();
   }
 
-  void set_rng_kernel(std::shared_ptr<RNG_TYPE> rng_kernel) {
+  void set_rng_kernel(std::shared_ptr<RNG_KERNEL_T> rng_kernel) {
     this->rng_kernel = rng_kernel;
   }
 
-  std::shared_ptr<RNG_TYPE> get_rng_kernel() { return this->rng_kernel; }
+  std::shared_ptr<RNG_KERNEL_T> get_rng_kernel() { return this->rng_kernel; }
 
   static constexpr size_t get_dim() { return dim; }
 
@@ -153,7 +153,7 @@ struct AbstractReactionData {
    * @brief Getter for the SYCL device-specific
    * struct.
    */
-  const ON_DEVICE_TYPE &get_on_device_obj() {
+  const ON_DEVICE_T &get_on_device_obj() {
 
     NESOASSERT(this->on_device_obj.has_value(),
                "on_device_obj in AbstractReactionData not initialised");
@@ -161,20 +161,20 @@ struct AbstractReactionData {
   }
 
 protected:
-  std::optional<ON_DEVICE_TYPE> on_device_obj;
-  ARGUMENT_PACK argument_pack;
-  std::shared_ptr<RNG_TYPE> rng_kernel;
+  std::optional<ON_DEVICE_T> on_device_obj;
+  ARGUMENT_PACK_T argument_pack;
+  std::shared_ptr<RNG_KERNEL_T> rng_kernel;
   std::map<int, std::string> properties_map;
 };
 
-template <typename ACCESSOR_PACK, size_t dim = 1,
-          typename RNG_TYPE = DEFAULT_RNG_KERNEL, size_t input_dim = 0,
-          typename VAL_TYPE = REAL, typename IN_TYPE = REAL>
+template <typename ACCESSOR_PACK_T, size_t dim = 1,
+          typename RNG_KERNEL_T = DEFAULT_RNG_KERNEL, size_t input_dim = 0,
+          typename VALUE_T = REAL, typename INPUT_T = REAL>
 struct AbstractReactionDataOnDevice {
-  using RNG_KERNEL_TYPE = RNG_TYPE;
-  using ACC_PACK = ACCESSOR_PACK;
-  using VALUE_TYPE = VAL_TYPE;
-  using INPUT_TYPE = IN_TYPE;
+  using RNG_KERNEL_TYPE = RNG_KERNEL_T;
+  using ACCESSOR_PACK_TYPE = ACCESSOR_PACK_T;
+  using VALUE_TYPE = VALUE_T;
+  using INPUT_TYPE = INPUT_T;
   static const size_t DIM = dim;
   static const size_t INPUT_DIM = input_dim;
 
@@ -182,18 +182,18 @@ struct AbstractReactionDataOnDevice {
 
   template <std::size_t D = INPUT_DIM,
             std::enable_if_t<(D == 0) && D == INPUT_DIM, int> = 0>
-  std::array<VAL_TYPE, dim>
-  calc_data(const ACCESSOR_PACK &accessor_pack,
-            typename RNG_TYPE::KernelType &rng_kernel) const {
+  std::array<VALUE_T, dim>
+  calc_data(const ACCESSOR_PACK_T &accessor_pack,
+            typename RNG_KERNEL_T::KernelType &rng_kernel) const {
     return std::array<REAL, dim>{0.0};
   }
 
   template <std::size_t D = INPUT_DIM,
             std::enable_if_t<(D > 0) && D == INPUT_DIM, int> = 0>
-  std::array<VAL_TYPE, dim>
-  calc_data(const std::array<IN_TYPE, INPUT_DIM> &input,
-            const ACCESSOR_PACK &accessor_pack,
-            typename RNG_TYPE::KernelType &rng_kernel) const {
+  std::array<VALUE_T, dim>
+  calc_data(const std::array<INPUT_T, INPUT_DIM> &input,
+            const ACCESSOR_PACK_T &accessor_pack,
+            typename RNG_KERNEL_T::KernelType &rng_kernel) const {
     return std::array<REAL, dim>{0.0};
   }
   static constexpr size_t get_dim() { return dim; }

--- a/src/reactions_lib/reaction_data_abstract.hpp
+++ b/src/reactions_lib/reaction_data_abstract.hpp
@@ -1,0 +1,203 @@
+#ifndef REACTIONS_REACTION_DATA_ABSTRACT_H
+#define REACTIONS_REACTION_DATA_ABSTRACT_H
+#include "reaction_kernel_pre_reqs.hpp"
+#include <memory>
+#include <neso_particles.hpp>
+#include <type_traits>
+#include <utility>
+
+using namespace NESO::Particles;
+namespace VANTAGE::Reactions {
+
+using DEFAULT_RNG_KERNEL = NullKernelRNG<REAL>;
+
+/**
+ * @brief Compile-time helpers for checking that a derived on-device
+ * reaction-data type defines calc_data with the correct parameter signature and
+ * return type.
+ *
+ * These traits use std::void_t SFINAE (Substitution Failure Is Not An Error) to
+ * detect whether T::calc_data(Args...) is a well-formed expression, and if
+ * so, what type it returns.  They are used automatically inside
+ * AbstractReactionData::validate_on_device_type(), and may also be used
+ * manually in derived-class constructors if desired.
+ */
+namespace calc_data_traits {
+
+// Primary template: calc_data(Args...) is NOT a valid expression.
+template <typename, typename = void, typename...> struct calc_data_traits {
+  static constexpr bool is_callable = false;
+  using return_type = void;
+};
+
+/** Partial specialization: selected only when
+ *  std::declval<const T>().calc_data(std::declval<Args>()...) is
+ *  well-formed. std::void_t produces void for a valid expression
+ *  and triggers SFINAE (Substitution Failure Is Not An Error) for an
+ *  invalid one, causing the compiler to fall back to the primary
+ *  template above.
+ */
+template <typename T, typename... Args>
+struct calc_data_traits<T,
+                        std::void_t<decltype(std::declval<const T>().calc_data(
+                            std::declval<Args>()...))>,
+                        Args...> {
+  static constexpr bool is_callable = true;
+  using return_type =
+      decltype(std::declval<const T>().calc_data(std::declval<Args>()...));
+};
+
+} // namespace calc_data_traits
+
+/**
+ * @brief true if T::calc_data(Args...) is a valid call expression.
+ */
+template <typename T, typename... Args>
+inline constexpr bool is_abstract_calc_data_callable_v =
+    calc_data_traits::calc_data_traits<T, void, Args...>::is_callable;
+
+/**
+ * @brief The return type of T::calc_data(Args...) (or void if not
+ * callable).
+ */
+template <typename T, typename... Args>
+using abstract_calc_data_return_t =
+    typename calc_data_traits::calc_data_traits<T, void, Args...>::return_type;
+
+/**
+ * @brief Check whether T::calc_data(Args...) returns exactly Expected.
+ *
+ * This helper short-circuits: if the parameter signature is wrong,
+ * is_abstract_calc_data_callable_v is false and the function returns true
+ * so that a separate static_assert on parameter mismatch can be the
+ * only error emitted.  When the parameter signature is correct but
+ * the return type differs, it returns false.
+ */
+template <typename T, typename Expected, typename... Args>
+constexpr bool check_abstract_calc_data_return_type() {
+  if constexpr (is_abstract_calc_data_callable_v<T, Args...>) {
+    return std::is_same_v<abstract_calc_data_return_t<T, Args...>, Expected>;
+  } else {
+    return true;
+  }
+}
+
+template <typename ON_DEVICE_TYPE, typename ARGUMENT_PACK, size_t dim = 1,
+          typename RNG_TYPE = DEFAULT_RNG_KERNEL, size_t input_dim = 0>
+struct AbstractReactionData {
+
+  using RNG_KERNEL_TYPE = RNG_TYPE;
+  using ARG_PACK = ARGUMENT_PACK;
+  using ON_DEVICE_OBJ_TYPE = ON_DEVICE_TYPE;
+  static const size_t DIM = dim;
+  static const size_t INPUT_DIM = input_dim;
+
+  /**
+   * @brief Validate that the on-device type defines calc_data with the
+   * parameter signature and return type expected by this host base class.
+   */
+  static constexpr bool validate_on_device_type() {
+    if constexpr (ON_DEVICE_TYPE::INPUT_DIM > 0) {
+      using input_t = const std::array<typename ON_DEVICE_TYPE::INPUT_TYPE,
+                                       ON_DEVICE_TYPE::INPUT_DIM> &;
+
+      static_assert(is_abstract_calc_data_callable_v<
+                        ON_DEVICE_TYPE, input_t,
+                        const typename ON_DEVICE_TYPE::ACC_PACK &,
+                        typename RNG_TYPE::KernelType &>,
+                    "ON_DEVICE_TYPE::calc_data parameter signature mismatch");
+
+      static_assert(check_abstract_calc_data_return_type<
+                        ON_DEVICE_TYPE,
+                        std::array<typename ON_DEVICE_TYPE::VALUE_TYPE,
+                                   ON_DEVICE_TYPE::DIM>,
+                        input_t, const typename ON_DEVICE_TYPE::ACC_PACK &,
+                        typename RNG_TYPE::KernelType &>(),
+                    "ON_DEVICE_TYPE::calc_data return type mismatch");
+    }
+    return true;
+  }
+
+  AbstractReactionData(
+      ARGUMENT_PACK argument_pack,
+      std::map<int, std::string> properties_map = get_default_map())
+      : argument_pack(argument_pack), properties_map(properties_map) {
+
+    static_assert(validate_on_device_type());
+    this->rng_kernel = std::make_shared<RNG_TYPE>();
+  }
+
+  ARGUMENT_PACK get_arg_pack() { return this->argument_pack; }
+  void set_arg_pack(const ARGUMENT_PACK &argument_pack) {
+    this->argument_pack = argument_pack;
+    this->index_on_device_object();
+  }
+
+  void set_rng_kernel(std::shared_ptr<RNG_TYPE> rng_kernel) {
+    this->rng_kernel = rng_kernel;
+  }
+
+  std::shared_ptr<RNG_TYPE> get_rng_kernel() { return this->rng_kernel; }
+
+  static constexpr size_t get_dim() { return dim; }
+
+  virtual ~AbstractReactionData() = default;
+
+  /**
+   * @brief To be implemented by each derived class in order to handle required
+   * property indexing on the on-device object
+   */
+  virtual void index_on_device_object() {};
+
+  /**
+   * @brief Getter for the SYCL device-specific
+   * struct.
+   */
+  const ON_DEVICE_TYPE &get_on_device_obj() {
+
+    NESOASSERT(this->on_device_obj.has_value(),
+               "on_device_obj in AbstractReactionData not initialised");
+    return this->on_device_obj.value();
+  }
+
+protected:
+  std::optional<ON_DEVICE_TYPE> on_device_obj;
+  ARGUMENT_PACK argument_pack;
+  std::shared_ptr<RNG_TYPE> rng_kernel;
+  std::map<int, std::string> properties_map;
+};
+
+template <typename ACCESSOR_PACK, size_t dim = 1,
+          typename RNG_TYPE = DEFAULT_RNG_KERNEL, size_t input_dim = 0,
+          typename VAL_TYPE = REAL, typename IN_TYPE = REAL>
+struct AbstractReactionDataOnDevice {
+  using RNG_KERNEL_TYPE = RNG_TYPE;
+  using ACC_PACK = ACCESSOR_PACK;
+  using VALUE_TYPE = VAL_TYPE;
+  using INPUT_TYPE = IN_TYPE;
+  static const size_t DIM = dim;
+  static const size_t INPUT_DIM = input_dim;
+
+  AbstractReactionDataOnDevice() = default;
+
+  template <std::size_t D = INPUT_DIM,
+            std::enable_if_t<(D == 0) && D == INPUT_DIM, int> = 0>
+  std::array<VAL_TYPE, dim>
+  calc_data(const ACCESSOR_PACK &accessor_pack,
+            typename RNG_TYPE::KernelType &rng_kernel) const {
+    return std::array<REAL, dim>{0.0};
+  }
+
+  template <std::size_t D = INPUT_DIM,
+            std::enable_if_t<(D > 0) && D == INPUT_DIM, int> = 0>
+  std::array<VAL_TYPE, dim>
+  calc_data(const std::array<IN_TYPE, INPUT_DIM> &input,
+            const ACCESSOR_PACK &accessor_pack,
+            typename RNG_TYPE::KernelType &rng_kernel) const {
+    return std::array<REAL, dim>{0.0};
+  }
+  static constexpr size_t get_dim() { return dim; }
+};
+
+}; // namespace VANTAGE::Reactions
+#endif

--- a/test/unit/test_pair_data_calculator.cpp
+++ b/test/unit/test_pair_data_calculator.cpp
@@ -1,0 +1,285 @@
+#include "include/mock_particle_group.hpp"
+#include <gtest/gtest.h>
+#include <random>
+#include <vector>
+
+using namespace NESO::Particles;
+using namespace VANTAGE::Reactions;
+
+template <size_t ndim = 2>
+inline auto create_test_particle_groups_pairs(int N_total)
+    -> std::tuple<ParticleGroupSharedPtr, ParticleGroupSharedPtr> {
+
+  auto dims = std::vector<int>(ndim, 2);
+
+  const double cell_extent = 1.0;
+  const int subdivision_order = 1;
+  const int stencil_width = 1;
+
+  const int pre_subdivision_cells =
+      std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<int>());
+
+  const int global_cell_count =
+      pre_subdivision_cells * std::pow(std::pow(2, subdivision_order), ndim);
+  const int npart_per_cell =
+      std::round((double)N_total / (double)global_cell_count);
+
+  auto mesh =
+      std::make_shared<CartesianHMesh>(MPI_COMM_WORLD, ndim, dims, cell_extent,
+                                       subdivision_order, stencil_width);
+
+  auto sycl_target =
+      std::make_shared<SYCLTarget>(GPU_SELECTOR, mesh->get_comm());
+
+  auto cart_local_mapper = CartesianHMeshLocalMapper(sycl_target, mesh);
+
+  auto domain = std::make_shared<Domain>(mesh, cart_local_mapper);
+
+  ParticleSpec particle_spec{
+      ParticleProp(Sym<REAL>("POSITION"), ndim, true),
+      ParticleProp(Sym<REAL>("VELOCITY"), ndim),
+      ParticleProp(Sym<INT>("CELL_ID"), 1, true),
+      ParticleProp(Sym<INT>("REACTIONS_PANIC_FLAG"), 1),
+      ParticleProp(Sym<INT>("REACTIONS_GROUPING_INDEX"), 1),
+      ParticleProp(Sym<INT>("REACTIONS_LINEAR_INDEX"), 1),
+      ParticleProp(Sym<INT>("PARTICLE_REACTED_FLAG"), 1),
+      ParticleProp(Sym<INT>("ID"), 1),
+      ParticleProp(Sym<REAL>("TOT_REACTION_RATE"), 1),
+      ParticleProp(Sym<REAL>("WEIGHT"), 1),
+      ParticleProp(Sym<INT>("INTERNAL_STATE"), 1),
+      ParticleProp(Sym<REAL>("ELECTRON_TEMPERATURE"), 1),
+      ParticleProp(Sym<REAL>("ELECTRON_DENSITY"), 1),
+      ParticleProp(Sym<REAL>("ELECTRON_SOURCE_ENERGY"), 1),
+      ParticleProp(Sym<REAL>("ELECTRON_SOURCE_MOMENTUM"), ndim),
+      ParticleProp(Sym<REAL>("ELECTRON_SOURCE_DENSITY"), 1),
+      ParticleProp(Sym<REAL>("ION_SOURCE_DENSITY"), 1),
+      ParticleProp(Sym<REAL>("ION_SOURCE_MOMENTUM"), ndim),
+      ParticleProp(Sym<REAL>("ION_SOURCE_ENERGY"), 1),
+      ParticleProp(Sym<REAL>("ION2_SOURCE_DENSITY"), 1),
+      ParticleProp(Sym<REAL>("ION2_SOURCE_MOMENTUM"), ndim),
+      ParticleProp(Sym<REAL>("ION2_SOURCE_ENERGY"), 1),
+      ParticleProp(Sym<REAL>("FLUID_DENSITY"), 1),
+      ParticleProp(Sym<REAL>("FLUID_FLOW_SPEED"), ndim),
+      ParticleProp(Sym<REAL>("FLUID_TEMPERATURE"), 1)};
+  auto particle_group_a =
+      std::make_shared<ParticleGroup>(domain, particle_spec, sycl_target);
+
+  auto particle_group_b =
+      std::make_shared<ParticleGroup>(domain, particle_spec, sycl_target);
+  const int rank = sycl_target->comm_pair.rank_parent;
+  const int size = sycl_target->comm_pair.size_parent;
+
+  std::mt19937 rng_pos(52234234 + rank);
+  std::mt19937 rng_vel(52234231 + rank);
+  std::mt19937 rng_rank(18241);
+
+  const int cell_count = domain->mesh->get_cell_count();
+  const int N = npart_per_cell * cell_count;
+
+  std::vector<std::vector<double>> positions;
+  std::vector<int> cells;
+  uniform_within_cartesian_cells(mesh, npart_per_cell, positions, cells,
+                                 rng_pos);
+
+  auto velocities =
+      NESO::Particles::normal_distribution(N, ndim, 0.0, 0.5, rng_vel);
+  // std::uniform_int_distribution<int> uniform_dist(
+  //     0, size - 1);
+  ParticleSet initial_distribution(N, particle_group_a->get_particle_spec());
+  for (int px = 0; px < N; px++) {
+    for (int dimx = 0; dimx < ndim; dimx++) {
+      initial_distribution[Sym<REAL>("POSITION")][px][dimx] =
+          positions.at(dimx).at(px);
+      initial_distribution[Sym<REAL>("VELOCITY")][px][dimx] =
+          velocities.at(dimx).at(px);
+      initial_distribution[Sym<REAL>("ELECTRON_SOURCE_MOMENTUM")][px][dimx] =
+          0.0;
+      initial_distribution[Sym<REAL>("FLUID_FLOW_SPEED")][px][dimx] =
+          1.0 + 2.0 * dimx;
+    }
+    initial_distribution[Sym<INT>("CELL_ID")][px][0] = cells.at(px);
+    initial_distribution[Sym<INT>("ID")][px][0] = px;
+    initial_distribution[Sym<REAL>("TOT_REACTION_RATE")][px][0] = 0.0;
+    initial_distribution[Sym<REAL>("WEIGHT")][px][0] = 1.0;
+    initial_distribution[Sym<INT>("INTERNAL_STATE")][px][0] = 0;
+    initial_distribution[Sym<REAL>("ELECTRON_TEMPERATURE")][px][0] = 2.0;
+    initial_distribution[Sym<REAL>("ELECTRON_DENSITY")][px][0] = 3.0e18;
+    initial_distribution[Sym<REAL>("ELECTRON_SOURCE_ENERGY")][px][0] = 0.0;
+    initial_distribution[Sym<REAL>("ELECTRON_SOURCE_DENSITY")][px][0] = 0.0;
+    initial_distribution[Sym<REAL>("FLUID_DENSITY")][px][0] = 3.0e18;
+    initial_distribution[Sym<REAL>("FLUID_TEMPERATURE")][px][0] = 2.0;
+  }
+  particle_group_a->add_particles_local(initial_distribution);
+
+  for (int px = 0; px < N; px++) {
+    initial_distribution[Sym<INT>("INTERNAL_STATE")][px][0] = 1;
+  }
+
+  particle_group_b->add_particles_local(initial_distribution);
+  auto pbc_a = std::make_shared<CartesianPeriodic>(
+      sycl_target, mesh, particle_group_a->position_dat);
+  auto ccb_a = std::make_shared<CartesianCellBin>(
+      sycl_target, mesh, particle_group_a->position_dat,
+      particle_group_a->cell_id_dat);
+
+  auto pbc_b = std::make_shared<CartesianPeriodic>(
+      sycl_target, mesh, particle_group_b->position_dat);
+  auto ccb_b = std::make_shared<CartesianCellBin>(
+      sycl_target, mesh, particle_group_b->position_dat,
+      particle_group_a->cell_id_dat);
+
+  pbc_a->execute();
+  particle_group_a->hybrid_move();
+  ccb_a->execute();
+  particle_group_a->cell_move();
+
+  pbc_b->execute();
+  particle_group_b->hybrid_move();
+  ccb_b->execute();
+  particle_group_b->cell_move();
+
+  MPI_Barrier(sycl_target->comm_pair.comm_parent);
+
+  return std::tuple(particle_group_a, particle_group_b);
+}
+
+TEST(PairDataCalculator, cs_reaction_data_single_simple) {
+  // This is a hard-coded number of particles so we get a round number for pair
+  // construction (800/16 = 40 particles per cell, which is 20 pairs)
+  const int N_total = 800;
+
+  auto A = create_test_particle_group(N_total);
+
+  int cell_count = A->domain->mesh->get_cell_count();
+
+  auto cellwise_pair_listA =
+      std::make_shared<CellwisePairListSimple>(A->sycl_target, cell_count);
+
+  std::vector<int> c;
+  std::vector<int> i;
+  std::vector<int> j;
+
+  int npart_cell = std::round(A->get_npart_local() /
+                              (double)A->domain->mesh->get_cell_count());
+
+  c.reserve(cell_count * npart_cell / 2);
+  i.reserve(cell_count * npart_cell / 2);
+  j.reserve(cell_count * npart_cell / 2);
+
+  std::mt19937 rng(9124234 + A->sycl_target->comm_pair.rank_parent);
+
+  for (int cellx = 0; cellx < cell_count; cellx++) {
+    npart_cell = A->get_npart_cell(cellx);
+    std::vector<int> pairs(npart_cell);
+    std::iota(pairs.begin(), pairs.end(), 0);
+    std::shuffle(pairs.begin(), pairs.end(), rng);
+    for (int px = 0; px < (npart_cell / 2); px++) {
+      c.push_back(cellx);
+      i.push_back(pairs.at(2 * px));
+      j.push_back(pairs.at(2 * px + 1));
+    }
+  }
+
+  cellwise_pair_listA->push_back(c, i, j);
+
+  auto cs_data = CSPairData<2>(ConstantRateCrossSection(2.5));
+  auto pair_data_calculator = PairDataCalculator(cs_data);
+
+  auto nd_arr = std::make_shared<NDLocalArray<REAL, 2>>(
+      A->sycl_target, cell_count * npart_cell / 2, 1);
+
+  nd_arr->fill(0);
+
+  auto pair_list = CellwisePairListAbsolute<ParticleGroup, CellwisePairList>(
+      A, A, cellwise_pair_listA);
+
+  pair_data_calculator.fill_buffer(nd_arr, pair_list, 0, cell_count);
+
+  auto nd_arr_host = nd_arr->get();
+
+  for (int i = 0; i < nd_arr_host.size(); i++) {
+    EXPECT_DOUBLE_EQ(nd_arr_host.at(i), 2.5);
+  }
+
+  A->sycl_target->free();
+  A->domain->mesh->free();
+}
+
+TEST(PairDataCalculator, cs_reaction_data_simple_and_constant) {
+  const int N_total = 800;
+
+  auto [A, B] = create_test_particle_groups_pairs(N_total);
+
+  particle_loop(
+      "set_vel_A", A,
+      [=](auto vel) {
+        vel[0] = 2;
+        vel[1] = 0;
+      },
+      Access::write(Sym<REAL>("VELOCITY")))
+      ->execute();
+
+  particle_loop(
+      "set_vel_B", B,
+      [=](auto vel) {
+        vel[0] = 4;
+        vel[1] = 0;
+      },
+      Access::write(Sym<REAL>("VELOCITY")))
+      ->execute();
+
+  int cell_count = A->domain->mesh->get_cell_count();
+
+  auto cellwise_pair_list =
+      std::make_shared<CellwisePairListSimple>(A->sycl_target, cell_count);
+
+  std::vector<int> c;
+  std::vector<int> i;
+  std::vector<int> j;
+
+  int npart_cell = std::round(A->get_npart_local() /
+                              (double)A->domain->mesh->get_cell_count());
+  c.reserve(cell_count * npart_cell);
+  i.reserve(cell_count * npart_cell);
+  j.reserve(cell_count * npart_cell);
+
+  std::mt19937 rng(9124234 + A->sycl_target->comm_pair.rank_parent);
+
+  for (int cellx = 0; cellx < cell_count; cellx++) {
+    std::vector<int> pairs(npart_cell);
+    std::iota(pairs.begin(), pairs.end(), 0);
+    std::shuffle(pairs.begin(), pairs.end(), rng);
+    for (int px = 0; px < npart_cell; px++) {
+      c.push_back(cellx);
+      i.push_back(pairs.at(px));
+      j.push_back(pairs.at(px));
+    }
+  }
+
+  cellwise_pair_list->push_back(c, i, j);
+
+  auto cs_data = CSPairData<2>(ConstantRateCrossSection(2.5));
+  auto cs_data_constant =
+      CSPairData<2, ConstantCrossSection>(ConstantCrossSection(2.5, 1.0));
+  auto pair_data_calculator = PairDataCalculator(cs_data, cs_data_constant);
+
+  auto nd_arr = std::make_shared<NDLocalArray<REAL, 2>>(
+      A->sycl_target, cell_count * npart_cell, 2);
+
+  nd_arr->fill(0);
+
+  auto pair_list = CellwisePairListAbsolute<ParticleGroup, CellwisePairList>(
+      A, B, cellwise_pair_list);
+
+  pair_data_calculator.fill_buffer(nd_arr, pair_list, 0, cell_count);
+
+  auto nd_arr_host = nd_arr->get();
+
+  for (int i = 0; i < nd_arr_host.size() - 1; i += 2) {
+    EXPECT_DOUBLE_EQ(nd_arr_host.at(i), 2.5);
+    EXPECT_DOUBLE_EQ(nd_arr_host.at(i + 1), 5.0);
+  }
+
+  A->sycl_target->free();
+  A->domain->mesh->free();
+}


### PR DESCRIPTION
# Pair reaction data and kernels

**Issue:** #233 

**Spack Spec(s) Tested:** spack-default.

**Environment details:** local machine

**Documentation PR(Optional):** To be done once all binary features are implemented

## Summary

See checklist.

## Checklist
- [x] `PairReactionData` - `particle_pair_loop`-compatible reaction data
- [x] `PairDataCalculator` - `particle_pair_loop`-based data calculator using the above data
- [x] `CSData` - `PairReactionData` using a cross-section object to return $\sigma v_r$
- [x] `ConstantCrossSection` - what it says on the tin...
- [ ] `PairReactionKernels` - `particle_pair_loop`-compatible reaction kernels   
- [ ] Updated the documentation.